### PR TITLE
Adding SignalsDateRangeContext

### DIFF
--- a/ccflow/context.py
+++ b/ccflow/context.py
@@ -1,7 +1,7 @@
 """This module defines re-usable contexts for the "Callable Model" framework defined in flow.callable.py."""
 
 from datetime import date, datetime
-from typing import Generic, Hashable, Optional, Sequence, Set, TypeVar
+from typing import Generic, Hashable, List, Optional, Sequence, Set, TypeVar
 
 from pydantic import field_validator, model_validator
 
@@ -25,6 +25,7 @@ __all__ = [
     "FreqHorizonDateContext",
     "FreqHorizonDateRangeContext",
     "SeededDateRangeContext",
+    "SignalsDateRangeContext",
     "SourceContext",
     "UniverseContext",
     "UniverseDateContext",
@@ -109,6 +110,10 @@ class DateRangeContext(ContextBase):
 
 class SeededDateRangeContext(DateRangeContext):
     seed: int = 1234
+
+
+class SignalsDateRangeContext(DateRangeContext):
+    signals: List[str]
 
 
 class VersionedDateContext(DateContext, EntryTimeContext):

--- a/ccflow/tests/test_context.py
+++ b/ccflow/tests/test_context.py
@@ -17,6 +17,7 @@ from ccflow.context import (
     ModelDateRangeSourceContext,
     ModelFreqDateRangeContext,
     NullContext,
+    SignalsDateRangeContext,
     UniverseContext,
     UniverseDateContext,
     UniverseDateRangeContext,
@@ -74,6 +75,14 @@ class TestContexts(TestCase):
         self.assertEqual(MyRangeModel(context={"start_date": d0, "end_date": d1}).context, c)
         self.assertEqual(MyRangeModel(context=("-1d", "0d")).context, c)
         self.assertEqual(MyRangeModel(context=["-1d", "0d"]).context, c)
+
+    def test_signal_date_range(self):
+        d0 = date.today() - timedelta(1)
+        d1 = date.today()
+        c = SignalsDateRangeContext(start_date=d0, end_date=d1, signals=["a", "b"])
+        self.assertEqual(SignalsDateRangeContext(start_date=str(d0), end_date=pd.Timestamp(date.today()), signals=["a", "b"]), c)
+        self.assertEqual(SignalsDateRangeContext(start_date="-1d", end_date="0d", signals=["a", "b"]), c)
+        self.assertRaises(ValueError, SignalsDateRangeContext, start_date=d0, end_date=d1, signals="foobar")
 
     def test_freq(self):
         self.assertEqual(


### PR DESCRIPTION
The SignalsDateRangeContext exists to provide users the ability to specify a list of string typed signal identifiers, perhaps to be used with something like the SQLReaderClass for runtime enabled filters on multiple signal types. 
