### PR TITLE
Pydantic validation of Narwhals types

### DIFF
--- a/ccflow/exttypes/narwhals.py
+++ b/ccflow/exttypes/narwhals.py
@@ -1,0 +1,225 @@
+import difflib
+import inspect
+import pprint
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Annotated, Any, Optional, Union, get_args, get_origin
+
+import narwhals.stable.v1 as nw
+from pydantic import AfterValidator, ConfigDict, GetCoreSchemaHandler, TypeAdapter
+from pydantic_core import core_schema
+
+__all__ = (
+    "FrameValidator",
+    "DataFrameValidator",
+    "LazyFrameValidator",
+    "FrameT",
+    "DataFrameT",
+    "LazyFrameT",
+    "DType",
+    "Schema",
+    "SchemaValidator",
+)
+
+
+class FrameValidator:
+    """Pydantic validator for Narwhals Frames.
+
+    When used directly (with lazy=None), it will raise a validation error if an eager frame is passed to a lazy frame source or vice versa.
+    """
+
+    lazy: Optional[bool] = None
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        source_origin = get_origin(source_type) or source_type
+        if source_origin == nw.DataFrame:
+            if cls.lazy is True:
+                raise TypeError(f"Must apply {cls.__name__} to a LazyFrame. Received {source_origin}.")
+        elif source_origin == nw.LazyFrame:
+            if cls.lazy is False:
+                raise TypeError(f"Must apply {cls.__name__} to a DataFrame. Received {source_origin}")
+        else:
+            raise TypeError(f"Must apply {cls.__name__} to a narwhals DataFrame or LazyFrame. Received {source_origin}")
+
+        # Prepare a TypeAdapter for validation of the generic argument, if present
+        source_args = get_args(source_type)
+        if source_args and source_args[0]:
+            source_arg_adapter = TypeAdapter(source_args[0], config=ConfigDict(arbitrary_types_allowed=True))
+        else:
+            source_arg_adapter = TypeAdapter(Any)
+
+        def validate_from_any(value: Any):
+            if isinstance(value, dict):
+                backend = None
+                if source_args and source_args[0] and source_args[0] is not Any:
+                    backend = source_args[0].__module__.split(".", 1)[0]
+
+                try:
+                    try:
+                        value = nw.from_dict(value, backend=backend)
+                    except AssertionError:  # Not implemented backend
+                        backend = None
+                        value = nw.from_dict(value, backend=backend)
+                except TypeError as e:
+                    raise ValueError(f"Fail to validate dict using nw.from_dict with backend {backend}") from e
+            else:
+                try:
+                    value = nw.from_native(value)
+                except TypeError as e:
+                    # pydantic validators should throw value errors
+                    raise ValueError("Fail to validate frame using nw.from_native") from e
+
+            if cls.lazy is True and isinstance(value, nw.DataFrame):
+                value = value.lazy()
+            if cls.lazy is False and isinstance(value, nw.LazyFrame):
+                value = value.collect()
+            if cls.lazy is None and not isinstance(value, source_origin):
+                raise ValueError(f"Expected {source_origin} but got {type(value)}")
+
+            try:
+                source_arg_adapter.validate_python(value.to_native())
+            except ValueError:
+                raise ValueError(f"Failed to match the generic argument ({source_args[0]}) of the Frame with {value.implementation}.") from None
+            return value
+
+        def serialize(value: Any):
+            if isinstance(value, nw.DataFrame):
+                return value.to_dict(as_series=False)
+            else:
+                raise ValueError("Cannot serialize a LazyFrame to JSON. Please use the collect() method to convert it to a DataFrame first.")
+
+        from_any_schema = core_schema.no_info_plain_validator_function(validate_from_any)
+        return core_schema.json_or_python_schema(
+            json_schema=from_any_schema,
+            python_schema=from_any_schema,
+            serialization=core_schema.plain_serializer_function_ser_schema(serialize),
+        )
+
+
+class DataFrameValidator(FrameValidator):
+    """Pydantic validator for Narwhals DataFrame.
+
+    Will collect lazy frames and convert them to eager frames.
+    """
+
+    lazy: Optional[bool] = False
+
+
+class LazyFrameValidator(FrameValidator):
+    """Pydantic validator for Narwhals LazyFrame.
+
+    Will create lazy frames out of eager data frames.
+    """
+
+    lazy: Optional[bool] = True
+
+
+# Mirror nw.DataFrameT and nw.FrameT (but with validation) for consistency. LazyFrameT added for convenience and symmetry.
+DataFrameT = Annotated[nw.DataFrame, DataFrameValidator()]
+LazyFrameT = Annotated[nw.LazyFrame, LazyFrameValidator()]
+FrameT = Union[Annotated[nw.DataFrame, FrameValidator()], Annotated[nw.LazyFrame, FrameValidator()]]
+
+
+class _DTypeValidator:
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        if not inspect.isclass(source_type) or not issubclass(source_type, nw.dtypes.DType):
+            raise TypeError(f"Must apply DTypeValidator to a Narwhals DType. Received {source_type}")
+
+        def validate_from_any(value: Any):
+            if isinstance(value, str):
+                try:
+                    value = getattr(nw, value)
+                except AttributeError:
+                    raise ValueError(f"Fail to find a narwhals DType with name {value}.") from None
+            if inspect.isclass(value) and issubclass(value, nw.dtypes.DType):
+                value = value()
+            if not isinstance(value, nw.dtypes.DType):
+                raise ValueError(f"Expected a Narwhals DType but got {type(value)}")
+            return value
+
+        def serialize(value: Any):
+            if inspect.isclass(value) and issubclass(value, nw.dtypes.DType):
+                value = value()
+            if not isinstance(value, nw.dtypes.DType):
+                raise ValueError(f"Expected a Narwhals DType but got {type(value)}")
+            return str(value)
+
+        from_any_schema = core_schema.no_info_plain_validator_function(validate_from_any)
+        return core_schema.json_or_python_schema(
+            json_schema=from_any_schema,
+            python_schema=from_any_schema,
+            serialization=core_schema.plain_serializer_function_ser_schema(serialize),
+        )
+
+
+# Mirror nw.dtypes.DType (but with validation) for consistency
+DType = Annotated[nw.dtypes.DType, _DTypeValidator()]
+
+# Mirror nw.Schema (but with validation) for consistency
+Schema = Annotated[OrderedDict[str, DType], AfterValidator(func=nw.Schema)]
+
+
+@dataclass(frozen=True)
+class SchemaValidator:
+    """Validator to check the schema of a Narwhals Frame"""
+
+    schema: Schema
+    allow_subset: bool = False
+    check_ordering: bool = False
+    cast: bool = False
+
+    def __post_init__(self):
+        try:
+            super().__setattr__("schema", TypeAdapter(Schema).validate_python(self.schema))
+        except ValueError as e:
+            raise TypeError(f"Schema must be a valid Narwhals Schema. Received {self.schema}") from e
+
+    def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        def validate_schema(value: Any):
+            if not isinstance(value, (nw.DataFrame, nw.LazyFrame)):
+                raise ValueError(f"Expected a Narwhals DataFrame or LazyFrame but got {type(value)}")
+            schema = value.collect_schema()
+            if self.allow_subset:
+                schema = nw.Schema({k: v for k, v in schema.items() if k in self.schema})
+            if self.cast:
+                # Casting is not supported on lazy frames because we don't have per-column slicing or to_dict
+                if isinstance(value, nw.LazyFrame):
+                    raise ValueError("Casting is not supported for LazyFrames. Please collect the LazyFrame first.")
+                # Preserve ordering of input frame by inserting each column back into an empty dictionary
+                new_values = {}
+                new_schema = {}
+                for col, dtype in schema.items():
+                    if col in self.schema and self.schema[col] != dtype:
+                        try:
+                            new_values[col] = value[col].cast(self.schema[col])
+                        except Exception:
+                            raise ValueError(f"Failed to cast column {col} from {dtype} to {self.schema[col]}") from None
+                        new_schema[col] = self.schema[col]
+                    else:
+                        new_values[col] = value[col]
+                        new_schema[col] = dtype
+                value = nw.from_dict(new_values)
+                schema = nw.Schema(new_schema)
+
+            d1 = dict(schema)
+            d2 = dict(self.schema)
+            if d1 != d2:
+                diff = "\n" + "\n".join(difflib.ndiff(pprint.pformat(d1).splitlines(), pprint.pformat(d2).splitlines())) + "\n"
+                raise ValueError(f"Schema mismatch in column names or types: {diff}")
+            if self.check_ordering and schema != self.schema:
+                diff = "\n" + "\n".join(difflib.ndiff(pprint.pformat(schema).splitlines(), pprint.pformat(self.schema).splitlines())) + "\n"
+                raise ValueError(f"Schema mismatch in column ordering: {diff}")
+
+            return value
+
+        return core_schema.no_info_after_validator_function(validate_schema, handler(source_type))

--- a/ccflow/tests/exttypes/test_narwhals.py
+++ b/ccflow/tests/exttypes/test_narwhals.py
@@ -1,0 +1,383 @@
+from typing import Annotated, Any
+
+import narwhals.stable.v1 as nw
+import pandas as pd
+import polars as pl
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from ccflow.exttypes.narwhals import (
+    DataFrameT,
+    DataFrameValidator,
+    DType,
+    FrameT,
+    FrameValidator,
+    LazyFrameT,
+    LazyFrameValidator,
+    Schema,
+    SchemaValidator,
+)
+
+
+@pytest.fixture
+def data():
+    return {
+        "a": [1.0, 2.0, 3.0],
+        "b": [4, 5, 6],
+        "c": ["foo", "bar", "baz"],
+        "d": [0, 0, 0],
+    }
+
+
+@pytest.fixture
+def schema():
+    return {
+        "a": nw.Float64,
+        "b": nw.Int64,
+        "c": nw.String,
+        "d": nw.Int64,
+    }
+
+
+@pytest.mark.parametrize(
+    "test_type",
+    [
+        DataFrameT,
+        Annotated[nw.DataFrame, DataFrameValidator()],
+        Annotated[nw.DataFrame[Any], DataFrameValidator()],
+        Annotated[nw.DataFrame[pl.DataFrame], DataFrameValidator()],
+    ],
+)
+def test_dataframe_validation(data, test_type):
+    ta = TypeAdapter(test_type)
+    pl_df = pl.DataFrame(data)
+    assert isinstance(ta.validate_python(pl_df), nw.DataFrame)
+    assert isinstance(ta.validate_python(pl_df.lazy()), nw.DataFrame)
+
+    df = ta.validate_python(pl_df)
+    assert isinstance(ta.validate_python(df), nw.DataFrame)
+    assert isinstance(ta.validate_python(df.to_dict()), nw.DataFrame)
+
+
+@pytest.mark.parametrize(
+    "test_type",
+    [
+        LazyFrameT,
+        Annotated[nw.LazyFrame, LazyFrameValidator()],
+        Annotated[nw.LazyFrame[Any], LazyFrameValidator()],
+        Annotated[nw.LazyFrame[pl.LazyFrame], LazyFrameValidator()],
+    ],
+)
+def test_lazyframe_validation(data, test_type):
+    ta = TypeAdapter(test_type)
+    pl_df = pl.DataFrame(data).lazy()
+    assert isinstance(ta.validate_python(pl_df), nw.LazyFrame)
+    assert isinstance(ta.validate_python(pl_df.collect()), nw.LazyFrame)
+
+    df = ta.validate_python(pl_df)
+    assert isinstance(ta.validate_python(df), nw.LazyFrame)
+    assert isinstance(ta.validate_python(df.collect().to_dict()), nw.LazyFrame)
+
+
+@pytest.mark.parametrize(
+    "test_type",
+    [
+        FrameT,
+    ],
+)
+def test_frame_validation(data, test_type):
+    ta = TypeAdapter(test_type)
+    pl_df = pl.DataFrame(data)
+    assert isinstance(ta.validate_python(pl_df), nw.DataFrame)
+    assert isinstance(ta.validate_python(pl_df.lazy()), nw.LazyFrame)
+
+    df = ta.validate_python(pl_df)
+    assert isinstance(ta.validate_python(df), nw.DataFrame)
+    assert isinstance(ta.validate_python(df.to_dict()), nw.DataFrame)
+
+    df_lazy = ta.validate_python(pl_df.lazy())
+    assert isinstance(ta.validate_python(df_lazy), nw.LazyFrame)
+
+
+@pytest.mark.parametrize(
+    "test_type",
+    [
+        Annotated[nw.DataFrame, FrameValidator()],
+        Annotated[nw.DataFrame[Any], FrameValidator()],
+        Annotated[nw.DataFrame[pl.DataFrame], FrameValidator()],
+    ],
+)
+def test_frame_validation_eager(data, test_type):
+    ta = TypeAdapter(test_type)
+    pl_df = pl.DataFrame(data)
+    assert isinstance(ta.validate_python(pl_df), nw.DataFrame)
+
+    df = ta.validate_python(pl_df)
+    assert isinstance(ta.validate_python(df), nw.DataFrame)
+    assert isinstance(ta.validate_python(df.to_dict()), nw.DataFrame)
+
+    # FrameValidator will error on the wrong type of frame
+    with pytest.raises(ValidationError):
+        ta.validate_python(pl_df.lazy())
+
+
+@pytest.mark.parametrize(
+    "test_type",
+    [
+        Annotated[nw.LazyFrame, FrameValidator()],
+        Annotated[nw.LazyFrame[Any], FrameValidator()],
+        Annotated[nw.LazyFrame[pl.LazyFrame], FrameValidator()],
+    ],
+)
+def test_frame_validation_lazy(data, test_type):
+    ta = TypeAdapter(test_type)
+    pl_df_lazy = pl.DataFrame(data).lazy()
+    assert isinstance(ta.validate_python(pl_df_lazy), nw.LazyFrame)
+
+    df = ta.validate_python(pl_df_lazy)
+    assert isinstance(ta.validate_python(df), nw.LazyFrame)
+
+    # FrameValidator will error on the wrong type of frame
+    with pytest.raises(ValidationError):
+        ta.validate_python(pl_df_lazy.collect())
+
+
+def test_dataframe_validation_wrong_backend(data):
+    """Polars-backed dataframe will fail to validate as a pandas backed data frame"""
+    # Set backend to pandas
+    ta = TypeAdapter(Annotated[nw.DataFrame[pd.DataFrame], DataFrameValidator()])
+    pl_df = pl.DataFrame(data)
+    with pytest.raises(ValidationError):
+        ta.validate_python(pl_df)
+
+    ta = TypeAdapter(Annotated[nw.DataFrame[pl.LazyFrame], DataFrameValidator()])
+    with pytest.raises(ValidationError):
+        ta.validate_python(pl_df)
+
+    ta = TypeAdapter(Annotated[nw.LazyFrame[pl.DataFrame], LazyFrameValidator()])
+    pl_df_lazy = pl.DataFrame(data).lazy()
+    with pytest.raises(ValidationError):
+        ta.validate_python(pl_df_lazy)
+
+
+def test_validation_from_dict(data):
+    ta = TypeAdapter(DataFrameT)
+    with pytest.raises(ValidationError):
+        ta.validate_python(data)
+
+    ta = TypeAdapter(Annotated[nw.DataFrame[pl.DataFrame], DataFrameValidator()])
+    df = ta.validate_python(data)
+    assert isinstance(df, nw.DataFrame)
+    assert df.implementation == nw.Implementation.POLARS
+
+    ta = TypeAdapter(Annotated[nw.LazyFrame[pl.LazyFrame], LazyFrameValidator()])
+    df = ta.validate_python(data)
+    assert isinstance(df, nw.LazyFrame)
+    assert df.implementation == nw.Implementation.POLARS
+
+    ta = TypeAdapter(Annotated[nw.DataFrame[pl.DataFrame], FrameValidator()])
+    df = ta.validate_python(data)
+    assert isinstance(df, nw.DataFrame)
+    assert df.implementation == nw.Implementation.POLARS
+
+
+@pytest.mark.parametrize(
+    "test_type",
+    [
+        DataFrameT,
+        Annotated[nw.DataFrame, DataFrameValidator()],
+        Annotated[nw.DataFrame[Any], DataFrameValidator()],
+        Annotated[nw.DataFrame[pl.DataFrame], DataFrameValidator()],
+    ],
+)
+def test_dataframe_serialization(data, test_type):
+    ta = TypeAdapter(test_type)
+    pl_df = pl.DataFrame(data)
+    df = ta.validate_python(pl_df)
+    json = ta.dump_json(df)
+    assert isinstance(json, bytes)
+
+    # Need to specify a specific backend for deserialization
+    ta2 = TypeAdapter(Annotated[nw.DataFrame[pl.DataFrame], DataFrameValidator()])
+    df2 = ta2.validate_json(json)
+    assert isinstance(df2, nw.DataFrame)
+
+
+@pytest.mark.parametrize(
+    "test_type",
+    [
+        LazyFrameT,
+        Annotated[nw.LazyFrame, LazyFrameValidator()],
+        Annotated[nw.LazyFrame[Any], LazyFrameValidator()],
+        Annotated[nw.LazyFrame[pl.LazyFrame], LazyFrameValidator()],
+    ],
+)
+def test_lazyframe_serialization(data, test_type):
+    ta = TypeAdapter(test_type)
+    pl_df = pl.DataFrame(data)
+    df = ta.validate_python(pl_df)
+    with pytest.raises(ValueError):
+        ta.dump_json(df)
+
+
+@pytest.mark.parametrize(
+    "test_type",
+    [
+        Annotated[nw.DataFrame, LazyFrameValidator()],
+        Annotated[nw.LazyFrame, DataFrameValidator()],
+        Annotated[pl.DataFrame, DataFrameValidator()],
+        Annotated[pl.DataFrame, FrameValidator()],
+        Annotated[pl.LazyFrame, LazyFrameValidator()],
+        Annotated[pl.LazyFrame, FrameValidator()],
+    ],
+)
+def test_invalid_annotations(data, test_type):
+    with pytest.raises(TypeError):
+        TypeAdapter(test_type)
+
+
+def test_dtype_validation():
+    ta = TypeAdapter(DType)
+    assert isinstance(ta.validate_python(nw.Float64()), nw.dtypes.DType)
+    assert isinstance(ta.validate_python(nw.Float64), nw.dtypes.DType)
+    assert ta.validate_python(nw.Float64) == nw.Float64()
+    assert ta.validate_python(nw.String) == nw.String()
+
+    assert ta.validate_python("Float64") == nw.Float64()
+    assert ta.validate_python("String") == nw.String()
+
+    with pytest.raises(ValidationError):
+        ta.validate_python(None)
+
+    with pytest.raises(ValidationError):
+        ta.validate_python("foo")
+
+    with pytest.raises(ValidationError):
+        ta.validate_python("DataFrame")
+
+
+def test_dtype_serialization():
+    ta = TypeAdapter(DType)
+    assert isinstance(ta.dump_json(nw.Float64()), bytes)
+    assert isinstance(ta.validate_json(ta.dump_json(nw.Float64())), nw.dtypes.DType)
+    assert isinstance(ta.validate_json(ta.dump_json(nw.Float64)), nw.dtypes.DType)
+    assert ta.validate_json(ta.dump_json(nw.Float64())) == nw.Float64()
+    assert ta.validate_json(ta.dump_json(nw.Float64)) == nw.Float64()
+    assert ta.validate_json(ta.dump_json(nw.String())) == nw.String()
+    assert ta.validate_json(ta.dump_json(nw.String)) == nw.String()
+
+    with pytest.raises(ValueError):
+        ta.dump_json(None)
+
+    with pytest.raises(ValueError):
+        ta.dump_json("foo")
+
+
+def test_schema():
+    ta = TypeAdapter(Schema)
+    schema = nw.Schema({"a": nw.Float64(), "b": nw.Int64()})
+
+    result = ta.validate_python(schema)
+    assert isinstance(result, nw.Schema)
+    assert isinstance(result["a"], nw.dtypes.DType)
+    assert result == schema
+
+    result = ta.validate_python(dict(schema))
+    assert isinstance(result, nw.Schema)
+    assert isinstance(result["a"], nw.dtypes.DType)
+    assert result == schema
+
+    result = ta.validate_python({"a": "Float64", "b": "Int64"})
+    assert isinstance(result, nw.Schema)
+    assert isinstance(result["a"], nw.dtypes.DType)
+    assert result == schema
+
+    assert isinstance(ta.dump_json(schema), bytes)
+    result = ta.validate_json(ta.dump_json(schema))
+    assert isinstance(result, nw.Schema)
+    assert isinstance(result["a"], nw.dtypes.DType)
+    assert result == schema
+
+
+def test_schema_validator(schema):
+    # Make sure that validation of the schema itself is applied when constructing the SchemaValidator
+    validator = SchemaValidator(schema=schema)
+    assert isinstance(validator.schema, nw.Schema)
+    assert isinstance(validator.schema["a"], nw.dtypes.DType)
+
+    # Make sure it's frozen
+    with pytest.raises(AttributeError):
+        validator.allow_subset = True
+
+
+@pytest.mark.parametrize("test_type", [DataFrameT, LazyFrameT])
+def test_schema_validation(test_type, data, schema):
+    pl_df = pl.DataFrame(data)
+
+    ta = TypeAdapter(Annotated[test_type, SchemaValidator(schema=schema)])
+    assert isinstance(ta.validate_python(pl_df), (nw.DataFrame, nw.LazyFrame))
+
+
+@pytest.mark.parametrize("test_type", [DataFrameT, LazyFrameT])
+def test_schema_validation_subset(test_type, data, schema):
+    pl_df = pl.DataFrame(data)
+    # Remove a column from the schema
+    schema.pop("c")
+    ta = TypeAdapter(Annotated[test_type, SchemaValidator(schema=schema)])
+    with pytest.raises(ValidationError):
+        ta.validate_python(pl_df)
+
+    ta = TypeAdapter(Annotated[test_type, SchemaValidator(schema=schema, allow_subset=True)])
+    assert isinstance(ta.validate_python(pl_df), (nw.DataFrame, nw.LazyFrame))
+
+
+@pytest.mark.parametrize("test_type", [DataFrameT, LazyFrameT])
+def test_schema_validation_ordering(test_type, data, schema):
+    pl_df = pl.DataFrame(data)
+    # Remove a column from the schema
+    schema_b = schema.pop("b")
+    schema_c = schema.pop("c")
+
+    schema["b"] = schema_b
+    ta = TypeAdapter(Annotated[test_type, SchemaValidator(schema=schema, allow_subset=True, check_ordering=True)])
+    with pytest.raises(ValidationError):
+        ta.validate_python(pl_df)
+
+    ta = TypeAdapter(Annotated[test_type, SchemaValidator(schema=schema, allow_subset=True)])
+    assert isinstance(ta.validate_python(pl_df), (nw.DataFrame, nw.LazyFrame))
+
+    schema["c"] = schema_c
+    ta = TypeAdapter(Annotated[test_type, SchemaValidator(schema=schema)])
+    assert isinstance(ta.validate_python(pl_df), (nw.DataFrame, nw.LazyFrame))
+
+
+def test_schema_cast(data, schema):
+    pl_df = pl.DataFrame(data)
+    # Change the type of a column in the schema
+    schema["b"] = nw.Float64
+    ta = TypeAdapter(Annotated[DataFrameT, SchemaValidator(schema=schema, cast=True)])
+    df = ta.validate_python(pl_df)
+    assert isinstance(df, nw.DataFrame)
+    assert df.collect_schema()["b"] == nw.Float64
+
+
+def test_schema_cast_fails(data, schema):
+    pl_df = pl.DataFrame(data)
+    # Change the type of a column in the schema that will fail to cast
+    schema["c"] = nw.Float64
+    ta = TypeAdapter(Annotated[DataFrameT, SchemaValidator(schema=schema, cast=True)])
+    with pytest.raises(ValueError):
+        ta.validate_python(pl_df)
+
+
+def test_schema_cast_lazy_raises(data, schema):
+    pl_df = pl.DataFrame(data).lazy()
+    with pytest.raises(ValueError):
+        ta = TypeAdapter(Annotated[nw.LazyFrame, LazyFrameValidator(), SchemaValidator(schema=schema, cast=True)])
+        ta.validate_python(pl_df)
+
+
+def test_invalid_schema(schema):
+    schema["a"] = "float64"
+    with pytest.raises(TypeError):
+        TypeAdapter(Annotated[DataFrameT, SchemaValidator(schema=schema)])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "hydra-core",
     "IPython",
     "jinja2",
+    "narwhals",
     "numpy<3",
     "orjson",
     "pandas",


### PR DESCRIPTION
This will simplify #26, while also leading to support of several other underlying libraries without explicit work required!

Since this code was written natively against pydantic v2, the approach is much cleaner than what we use in these places:
 - https://github.com/Point72/ccflow/blob/main/ccflow/exttypes/arrow.py
 - https://github.com/Point72/ccflow/blob/main/ccflow/exttypes/pandas.py

With this functionality, I think we can deprecate some of those types.