### PR TITLE
Defer build to reduce import time

### DIFF
--- a/ccflow/base.py
+++ b/ccflow/base.py
@@ -177,6 +177,7 @@ class BaseModel(PydanticBaseModel, _RegistryMixin, metaclass=_SerializeAsAnyMeta
         # where the default behavior is just to drop the mis-named value. This prevents that
         extra="forbid",
         ser_json_timedelta="float",
+        defer_build=True,
     )
 
     def __str__(self):


### PR DESCRIPTION
Described in the pydantic docs here: https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.defer_build