### PR TITLE
Add generic function to load configs from hydra into the registry, taking into account the config-dir.

### DIFF
--- a/ccflow/base.py
+++ b/ccflow/base.py
@@ -4,6 +4,7 @@ import collections.abc
 import copy
 import inspect
 import logging
+import os
 import pathlib
 import platform
 import warnings
@@ -703,6 +704,83 @@ def resolve_str(v: str) -> ModelType:
         return search_registry[v]
     except KeyError:
         raise RegistryKeyError(f"Could not resolve model '{v}' in registry '{search_registry._debug_name}'")
+
+
+def _find_parent_config_folder(config_dir: str = "config", config_name: str = "", *, basepath: str = ""):
+    folder = pathlib.Path(basepath).resolve()
+    exists = (
+        (folder / config_dir).exists()
+        if not config_name
+        else ((folder / config_dir / f"{config_name}.yml").exists() or (folder / config_dir / f"{config_name}.yaml").exists())
+    )
+    while not exists:
+        folder = folder.parent
+        if str(folder) == os.path.abspath(os.sep):
+            raise FileNotFoundError(f"Could not find config folder: {config_dir} in folder {basepath}")
+        exists = (
+            (folder / config_dir).exists()
+            if not config_name
+            else ((folder / config_dir / f"{config_name}.yml").exists() or (folder / config_dir / f"{config_name}.yaml").exists())
+        )
+
+    config_dir = (folder / config_dir).resolve()
+    if not config_name:
+        return folder.resolve(), config_dir, ""
+    elif (folder / config_dir / f"{config_name}.yml").exists():
+        return folder.resolve(), config_dir, (folder / config_dir / f"{config_name}.yml").resolve()
+    return folder.resolve(), config_dir, (folder / config_dir / f"{config_name}.yaml").resolve()
+
+
+def load_config(
+    root_config_dir: str,
+    root_config_name: str,
+    config_dir: str = "config",
+    config_name: str = "",
+    overrides: Optional[List[str]] = None,
+    *,
+    overwrite: bool = False,
+    basepath: str = "",
+) -> RootModelRegistry:
+    """Helper function to load a hydra config into the root model registry.
+
+    Hydra configs can be pulled from multiple places:
+      1. A root configuration
+      2. An optional user-provided config directory, and within that, an optional config name.
+
+    Arguments:
+        root_config_dir: The directory containing the root hydra config. This is typically the location of the configs in, i.e. "config"
+         This is passed to hydra.initialize_config_dir to get the loading started.
+        root_config_name: The config name within the base directory, i.e. "conf"
+        config_dir: End user-provided additional directory to search for hydra configs.
+        config_name: An optional config name to look for within the `config_dir`. This allows you to specify a particular config file to load.
+        overrides: A list of hydra-style override strings to apply when loading the config.
+        overwrite: Whether to overwrite existing entries in the registry when loading the config.
+        basepath: The base path to start searching for the `config_dir`. This is useful when you want to load from an absolute (rather than relative) path.
+    """
+    # Heavy import, only import if used
+    import os
+
+    from hydra import compose, initialize_config_dir
+
+    overrides = overrides or []
+    with initialize_config_dir(config_dir=root_config_dir, version_base=None):
+        if config_dir:
+            hydra_folder, config_dir, _ = _find_parent_config_folder(config_dir=config_dir, config_name=config_name, basepath=basepath or os.getcwd())
+
+            cfg = compose(config_name=root_config_name, overrides=[], return_hydra_config=True)
+            searchpaths = cfg["hydra"]["searchpath"]
+            searchpaths.extend([hydra_folder, config_dir])
+            if config_name:
+                config_group = pathlib.Path(config_dir).resolve().name
+                overrides = [f"+{config_group}={config_name}", *overrides.copy(), f"hydra.searchpath=[{','.join(searchpaths)}]"]
+            else:
+                overrides = [*overrides.copy(), f"hydra.searchpath=[{','.join(searchpaths)}]"]
+
+        cfg = compose(config_name=root_config_name, overrides=overrides)
+
+    registry = ModelRegistry.root()
+    registry.load_config(cfg, overwrite=overwrite)
+    return registry
 
 
 class ResultBase(BaseModel):

--- a/ccflow/tests/config_user/sample.yaml
+++ b/ccflow/tests/config_user/sample.yaml
@@ -1,0 +1,9 @@
+user_foo:
+    _target_: ccflow.tests.test_base_registry.MyTestModel
+    a: test
+    b: 0.0
+    c:
+        - i
+        - j
+    d:
+        k: 2.0

--- a/ccflow/tests/config_user/sample2.yml
+++ b/ccflow/tests/config_user/sample2.yml
@@ -1,0 +1,6 @@
+user_bar:
+    _target_: ccflow.tests.test_base_registry.MyNestedModel
+    x: foo
+    y:  # Note that when type is defined on parent model, no need to specify _target_
+        a: test2
+        b: 2.0

--- a/ccflow/tests/test_base_load_config.py
+++ b/ccflow/tests/test_base_load_config.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+from ccflow.base import load_config
+
+
+def test_root_config():
+    root_config_dir = str(Path(__file__).resolve().parent / "config")
+    r = load_config(
+        root_config_dir=root_config_dir,
+        root_config_name="conf",
+        overwrite=True,
+    )
+    try:
+        assert len(r.models)
+        assert "foo" in r.models
+        assert "bar" in r.models
+    finally:
+        r.clear()
+
+
+def test_config_dir():
+    root_config_dir = str(Path(__file__).resolve().parent / "config")
+    config_dir = str(Path(__file__).resolve().parent / "config_user")
+    r = load_config(
+        root_config_dir=root_config_dir,
+        root_config_name="conf",
+        config_dir=config_dir,
+        overwrite=True,
+    )
+    try:
+        assert len(r.models)
+        assert "foo" in r.models
+        assert "bar" in r.models
+    finally:
+        r.clear()
+
+
+def test_config_name():
+    root_config_dir = str(Path(__file__).resolve().parent / "config")
+    config_dir = str(Path(__file__).resolve().parent / "config_user")
+    r = load_config(
+        root_config_dir=root_config_dir,
+        root_config_name="conf",
+        config_dir=config_dir,
+        config_name="sample",
+        overwrite=True,
+    )
+    try:
+        assert len(r.models)
+        assert "foo" in r.models
+        assert "bar" in r.models
+        assert "config_user" in r.models
+        assert "user_foo" in r["config_user"]
+    finally:
+        r.clear()
+
+
+def test_config_dir_with_overrides():
+    root_config_dir = str(Path(__file__).resolve().parent / "config")
+    config_dir = str(Path(__file__).resolve().parent)
+    r = load_config(
+        root_config_dir=root_config_dir,
+        root_config_name="conf",
+        config_dir=config_dir,
+        overrides=["+config_user=sample"],
+        overwrite=True,
+    )
+    try:
+        assert len(r.models)
+        assert "foo" in r.models
+        assert "bar" in r.models
+        assert "config_user" in r.models
+        assert "user_foo" in r["config_user"]
+    finally:
+        r.clear()
+
+
+def test_config_name_yml_not_yaml():
+    # TODO: Doesn't look like hydra supports yml
+    root_config_dir = str(Path(__file__).resolve().parent / "config")
+    config_dir = str(Path(__file__).resolve().parent / "config_user")
+    r = load_config(
+        root_config_dir=root_config_dir,
+        root_config_name="conf",
+        config_dir=config_dir,
+        config_name="sample2",
+        overwrite=True,
+    )
+    try:
+        assert len(r.models)
+        assert "foo" in r.models
+        assert "bar" in r.models
+        assert "config_user" in r.models
+        assert "user_bar" in r["config_user"]
+    finally:
+        r.clear()
+
+
+def test_config_dir_basepath():
+    root_config_dir = str(Path(__file__).resolve().parent / "config")
+    config_dir = "."
+    basepath = str(Path(__file__).resolve().parent)
+    r = load_config(
+        root_config_dir=root_config_dir,
+        root_config_name="conf",
+        config_dir=config_dir,
+        overrides=["+config_user=sample"],
+        overwrite=True,
+        basepath=basepath,
+    )
+    try:
+        assert len(r.models)
+        assert "foo" in r.models
+        assert "bar" in r.models
+        assert "config_user" in r.models
+        assert "user_foo" in r["config_user"]
+    finally:
+        r.clear()
+
+
+def test_config_dir_basepath_malformed():
+    root_config_dir = str(Path(__file__).resolve().parent / "config")
+    # By putting "config_user" in both the base path and the config dir, we are technically listing it twice,
+    # so it needs to go up a level to actually find the "config_user" directory.
+    basepath = str(Path(__file__).resolve().parent / "config_user")
+    r = load_config(
+        root_config_dir=root_config_dir,
+        root_config_name="conf",
+        config_dir="config_user",
+        config_name="sample",
+        overwrite=True,
+        basepath=basepath,
+    )
+    try:
+        assert len(r.models)
+        assert "foo" in r.models
+        assert "bar" in r.models
+        assert "config_user" in r.models
+        assert "user_foo" in r["config_user"]
+    finally:
+        r.clear()

--- a/ccflow/tests/test_base_load_config.py
+++ b/ccflow/tests/test_base_load_config.py
@@ -1,14 +1,23 @@
 from pathlib import Path
 
+import pytest
+
 from ccflow.base import load_config
 
 
-def test_root_config():
+@pytest.fixture
+def basepath():
+    # Because os.cwd may change depending on how tests are run
+    return str(Path(__file__).resolve().parent)
+
+
+def test_root_config(basepath):
     root_config_dir = str(Path(__file__).resolve().parent / "config")
     r = load_config(
         root_config_dir=root_config_dir,
         root_config_name="conf",
         overwrite=True,
+        basepath=basepath,
     )
     try:
         assert len(r.models)
@@ -18,7 +27,7 @@ def test_root_config():
         r.clear()
 
 
-def test_config_dir():
+def test_config_dir(basepath):
     root_config_dir = str(Path(__file__).resolve().parent / "config")
     config_dir = str(Path(__file__).resolve().parent / "config_user")
     r = load_config(
@@ -26,6 +35,7 @@ def test_config_dir():
         root_config_name="conf",
         config_dir=config_dir,
         overwrite=True,
+        basepath=basepath,
     )
     try:
         assert len(r.models)
@@ -35,7 +45,7 @@ def test_config_dir():
         r.clear()
 
 
-def test_config_name():
+def test_config_name(basepath):
     root_config_dir = str(Path(__file__).resolve().parent / "config")
     config_dir = str(Path(__file__).resolve().parent / "config_user")
     r = load_config(
@@ -44,6 +54,7 @@ def test_config_name():
         config_dir=config_dir,
         config_name="sample",
         overwrite=True,
+        basepath=basepath,
     )
     try:
         assert len(r.models)
@@ -55,51 +66,9 @@ def test_config_name():
         r.clear()
 
 
-def test_config_dir_with_overrides():
+def test_config_dir_with_overrides(basepath):
     root_config_dir = str(Path(__file__).resolve().parent / "config")
     config_dir = str(Path(__file__).resolve().parent)
-    r = load_config(
-        root_config_dir=root_config_dir,
-        root_config_name="conf",
-        config_dir=config_dir,
-        overrides=["+config_user=sample"],
-        overwrite=True,
-    )
-    try:
-        assert len(r.models)
-        assert "foo" in r.models
-        assert "bar" in r.models
-        assert "config_user" in r.models
-        assert "user_foo" in r["config_user"]
-    finally:
-        r.clear()
-
-
-def test_config_name_yml_not_yaml():
-    # TODO: Doesn't look like hydra supports yml
-    root_config_dir = str(Path(__file__).resolve().parent / "config")
-    config_dir = str(Path(__file__).resolve().parent / "config_user")
-    r = load_config(
-        root_config_dir=root_config_dir,
-        root_config_name="conf",
-        config_dir=config_dir,
-        config_name="sample2",
-        overwrite=True,
-    )
-    try:
-        assert len(r.models)
-        assert "foo" in r.models
-        assert "bar" in r.models
-        assert "config_user" in r.models
-        assert "user_bar" in r["config_user"]
-    finally:
-        r.clear()
-
-
-def test_config_dir_basepath():
-    root_config_dir = str(Path(__file__).resolve().parent / "config")
-    config_dir = "."
-    basepath = str(Path(__file__).resolve().parent)
     r = load_config(
         root_config_dir=root_config_dir,
         root_config_name="conf",
@@ -116,6 +85,20 @@ def test_config_dir_basepath():
         assert "user_foo" in r["config_user"]
     finally:
         r.clear()
+
+
+def test_config_name_yml_not_yaml(basepath):
+    root_config_dir = str(Path(__file__).resolve().parent / "config")
+    config_dir = str(Path(__file__).resolve().parent / "config_user")
+    with pytest.raises(ValueError):
+        load_config(
+            root_config_dir=root_config_dir,
+            root_config_name="conf",
+            config_dir=config_dir,
+            config_name="sample2",
+            overwrite=True,
+            basepath=basepath,
+        )
 
 
 def test_config_dir_basepath_malformed():


### PR DESCRIPTION
Adapted from [csp-gateway](https://github.com/Point72/csp-gateway/blob/ec84b6bd6ef3b66646f1fdbfdac8fee9cfe26588/csp_gateway/server/config/__init__.py#L50)

However, parameterized `root_config_dir` and `root_config_name` as this varies from repo to repo. Also it was hard-coding `config` in the overrides `f"+config={config_name}"`, whereas the override may have different names depending on config_dir