### PR TITLE
Add mixin to allow pulling key-value pairs from python objects

### DIFF
--- a/ccflow/__init__.py
+++ b/ccflow/__init__.py
@@ -11,4 +11,4 @@ from .models import *
 from .object_config import *
 from .publisher import *
 from .result import *
-from .utils import FileHandler, StreamHandler
+from .utils import FileHandler, PathKeyResolverMixin, StreamHandler

--- a/ccflow/tests/config/conf_mixin.yaml
+++ b/ccflow/tests/config/conf_mixin.yaml
@@ -1,0 +1,19 @@
+mixin_simple:
+  _target_: ccflow.tests.utils.test_mixin.MixinSimpleModel
+  ccflow_path: ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG
+
+mixin_db:
+  _target_: ccflow.tests.utils.test_mixin.MixinDatabaseConfigModel
+  ccflow_path: ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG
+  ccflow_keys: database
+
+mixin_parent:
+  _target_: ccflow.tests.utils.test_mixin.MixinParentModel
+  ccflow_path: ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG
+  child:
+    ccflow_path: ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG
+    ccflow_keys: database
+  plain_child:
+    host: plain.example.com
+    port: 3306
+    name: plain_db

--- a/ccflow/tests/data/__init__.py
+++ b/ccflow/tests/data/__init__.py
@@ -1,0 +1,11 @@
+"""Shared test data modules.
+
+Import sample configs using:
+
+    from ccflow.tests.data.path_key_resolver_samples import (
+        SIMPLE_CONFIG,
+        NESTED_CONFIG,
+        COMPLEX_CONFIG,
+        MIXED_TYPES_CONFIG,
+    )
+"""

--- a/ccflow/tests/data/path_key_resolver_samples.py
+++ b/ccflow/tests/data/path_key_resolver_samples.py
@@ -1,0 +1,44 @@
+"""Sample objects for testing PathKeyResolverMixin functionality."""
+
+# Simple dictionary for basic path resolution
+SIMPLE_CONFIG = {"name": "test_model", "version": "1.0", "enabled": True}
+
+# Nested dictionary for key-based access
+NESTED_CONFIG = {
+    "database": {"host": "localhost", "port": 5432, "name": "test_db"},
+    "cache": {"ttl": 3600, "max_size": 1000},
+    "features": {"feature_a": True, "feature_b": False},
+}
+
+# Complex nested structure
+COMPLEX_CONFIG = {
+    "environments": {
+        "dev": {"database": {"host": "dev.example.com", "port": 5432}, "debug": True},
+        "prod": {"database": {"host": "prod.example.com", "port": 5432}, "debug": False},
+    },
+    "shared": {"timeout": 30, "retries": 3},
+}
+
+# Additional test data with various types
+MIXED_TYPES_CONFIG = {
+    "string_val": "hello",
+    "int_val": 42,
+    "float_val": 3.14,
+    "bool_val": True,
+    "list_val": [1, 2, 3],
+    "dict_val": {"nested": "value"},
+}
+
+# Alternate nested config to test Hydra overrides of `path`/`key`
+OTHER_NESTED_CONFIG = {
+    "database": {"host": "override.local", "port": 6543, "name": "other_db"},
+    "database_alt": {"host": "alt.local", "port": 7777, "name": "alt_db"},
+    "cache": {"ttl": 7200, "max_size": 2000},
+    "features": {"feature_a": False, "feature_b": True},
+}
+
+# List of servers to test top-level integer key traversal
+SERVERS = [
+    {"host": "server1.local", "port": 1111, "name": "s1"},
+    {"host": "server2.local", "port": 2222, "name": "s2"},
+]

--- a/ccflow/tests/utils/test_mixin.py
+++ b/ccflow/tests/utils/test_mixin.py
@@ -1,0 +1,472 @@
+from typing import ClassVar, List
+
+import pytest
+from pydantic import ConfigDict, Field, ValidationError
+
+from ccflow import BaseModel
+from ccflow.utils import PathKeyResolverMixin
+
+
+# Top-level models for Hydra integration tests
+class MixinSimpleModel(BaseModel, PathKeyResolverMixin):
+    name: str = Field(default="default_name")
+    version: str = Field(default="0.0")
+    enabled: bool = Field(default=False)
+
+
+class MixinDatabaseConfigModel(BaseModel, PathKeyResolverMixin):
+    host: str = Field(default="localhost")
+    port: int = Field(default=5432)
+    name: str = Field(default="default_db")
+
+
+class PlainDatabaseConfig(BaseModel):
+    host: str = Field(default="localhost")
+    port: int = Field(default=5432)
+    name: str = Field(default="default_db")
+
+
+class MixinParentModel(BaseModel, PathKeyResolverMixin):
+    name: str = Field(default="default_name")
+    version: str = Field(default="0.0")
+    enabled: bool = Field(default=False)
+    child: MixinDatabaseConfigModel
+    plain_child: PlainDatabaseConfig
+
+
+# Local complex objects for import-path tests
+class _InnerBM(BaseModel):
+    val: int
+
+
+LOCAL_COMPLEX_WITH_BM = {"sub": _InnerBM(val=5)}
+
+
+class _PM(BaseModel):
+    a: int
+    b: str
+
+
+LOCAL_PM = {"pm": _PM(a=1, b="x")}
+
+
+class TestPathKeyResolverMixin:
+    """Test cases for PathKeyResolverMixin."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+
+        # Create a simple test model that uses the mixin
+        class SimpleTestModel(BaseModel, PathKeyResolverMixin):
+            name: str = Field(default="default_name")
+            version: str = Field(default="0.0")
+            enabled: bool = Field(default=False)
+
+        # Create a model with additional fields for merge testing
+        class MergeTestModel(BaseModel, PathKeyResolverMixin):
+            name: str = Field(default="default_name")
+            version: str = Field(default="0.0")
+            enabled: bool = Field(default=False)
+            extra_field: str = Field(default="extra_value")
+
+        self.SimpleTestModel = SimpleTestModel
+        self.MergeTestModel = MergeTestModel
+
+    def test_dict_without_path_key_is_unchanged(self):
+        """Test that dictionaries without 'path' key are processed normally."""
+        normal_config = {"name": "normal_model", "version": "1.5", "enabled": False}
+
+        model = self.SimpleTestModel(**normal_config)
+
+        assert model.name == "normal_model"
+        assert model.version == "1.5"
+        assert model.enabled is False
+
+    def test_basic_path_resolution(self):
+        """Test basic PyObjectPath resolution without key parameter."""
+        # Test data is in the test_data module
+        path_config = {"ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG"}
+
+        model = self.SimpleTestModel(**path_config)
+
+        # Values should be resolved from SIMPLE_CONFIG
+        assert model.name == "test_model"
+        assert model.version == "1.0"
+        assert model.enabled is True
+
+    def test_path_with_key_resolution(self):
+        """Test PyObjectPath resolution with key parameter."""
+
+        # Create a test model that matches the database config structure
+        class DatabaseConfigModel(BaseModel, PathKeyResolverMixin):
+            host: str = Field(default="localhost")
+            port: int = Field(default=5432)
+            name: str = Field(default="default_db")
+
+        path_config = {"ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG", "ccflow_keys": "database"}
+
+        model = DatabaseConfigModel(**path_config)
+
+        # Values should be resolved from NESTED_CONFIG["database"]
+        assert model.host == "localhost"
+        assert model.port == 5432
+        assert model.name == "test_db"
+
+    def test_value_merging_precedence(self):
+        """Test that resolved values take precedence over explicitly provided values."""
+        path_config = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG",
+            "name": "overridden_name",  # Will be overridden by resolved name
+            "version": "3.0",  # Will be overridden by resolved version
+            # enabled should come from the resolved config
+        }
+
+        model = self.SimpleTestModel(**path_config)
+
+        # Resolved values should override explicitly provided values
+        assert model.name == "test_model"  # From SIMPLE_CONFIG, not "overridden_name"
+        assert model.version == "1.0"  # From SIMPLE_CONFIG, not "3.0"
+        # Value from resolved config should be used
+        assert model.enabled is True
+
+    def test_partial_resolution_merging(self):
+        """Test merging when resolved config only provides some fields."""
+
+        # Create a model with more fields than what's in MIXED_TYPES_CONFIG
+        class ExtendedModel(BaseModel, PathKeyResolverMixin):
+            # Allow extra keys from the resolved dict to be ignored for this test
+            model_config = ConfigDict(extra="ignore")
+            string_val: str = Field(default="default_string")
+            int_val: int = Field(default=0)
+            bool_val: bool = Field(default=False)
+            missing_field: str = Field(default="default_missing")
+            extra_provided: str = Field(default="default_extra")
+
+        path_config = {"ccflow_path": "ccflow.tests.data.path_key_resolver_samples.MIXED_TYPES_CONFIG", "extra_provided": "explicitly_set"}
+
+        model = ExtendedModel(**path_config)
+
+        # Values from resolved config
+        assert model.string_val == "hello"
+        assert model.int_val == 42
+        assert model.bool_val is True
+        # Field not in resolved config should use default
+        assert model.missing_field == "default_missing"
+        # Explicitly provided field
+        assert model.extra_provided == "explicitly_set"
+
+    def test_invalid_path_handling(self):
+        """Test error handling for invalid PyObjectPath."""
+        path_config = {"ccflow_path": "non_existent.module.INVALID_CONFIG"}
+
+        with pytest.raises(Exception):  # Should raise some kind of validation error
+            self.SimpleTestModel(**path_config)
+
+    def test_invalid_key_handling(self):
+        """Test error handling for invalid key in resolved object."""
+        path_config = {"ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG", "ccflow_keys": "non_existent_key"}
+
+        with pytest.raises(KeyError):
+            self.SimpleTestModel(**path_config)
+
+    def test_path_resolves_to_non_dict(self):
+        """Test error handling when path resolves to non-dict object."""
+        # Add a non-dict object to our test data for this test
+        path_config = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.MIXED_TYPES_CONFIG",
+            "ccflow_keys": "string_val",  # This resolves to a string, not a dict
+        }
+
+        # The mixin will try to call values.update() with a string, which should cause a validation error
+        with pytest.raises((AttributeError, ValueError, TypeError)):
+            self.SimpleTestModel(**path_config)
+
+    def test_empty_path_handling(self):
+        """Test that empty path parameter is handled correctly."""
+        path_config = {"ccflow_path": ""}
+
+        with pytest.raises(Exception):
+            self.SimpleTestModel(**path_config)
+
+    def test_nested_models_mixed_mixins(self):
+        """Parent model (mixin) containing child mixin model and non-mixin model."""
+
+        class DatabaseConfigModel(BaseModel, PathKeyResolverMixin):
+            host: str = Field(default="localhost")
+            port: int = Field(default=5432)
+            name: str = Field(default="default_db")
+
+        class PlainDatabaseConfig(BaseModel):
+            host: str = Field(default="localhost")
+            port: int = Field(default=5432)
+            name: str = Field(default="default_db")
+
+        class ParentModel(BaseModel, PathKeyResolverMixin):
+            name: str = Field(default="default_name")
+            version: str = Field(default="0.0")
+            enabled: bool = Field(default=False)
+            child: DatabaseConfigModel
+            plain_child: PlainDatabaseConfig
+
+        parent_config = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG",
+            "child": {"ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG", "ccflow_keys": "database"},
+            "plain_child": {"host": "plain.example.com", "port": 3306, "name": "plain_db"},
+        }
+
+        model = ParentModel(**parent_config)
+
+        # Parent resolved from SIMPLE_CONFIG
+        assert model.name == "test_model"
+        assert model.version == "1.0"
+        assert model.enabled is True
+
+        # Child resolved via nested path/key
+        assert model.child.host == "localhost"
+        assert model.child.port == 5432
+        assert model.child.name == "test_db"
+
+        # Plain child uses provided explicit values only
+        assert model.plain_child.host == "plain.example.com"
+        assert model.plain_child.port == 3306
+        assert model.plain_child.name == "plain_db"
+
+    def test_nested_models_grandchild_mixins(self):
+        """Parent (mixin) -> child (mixin) with nested mixin fields resolved independently."""
+
+        class DatabaseConfigModel(BaseModel, PathKeyResolverMixin):
+            host: str = Field(default="localhost")
+            port: int = Field(default=5432)
+            name: str = Field(default="default_db")
+
+        class FeaturesModel(BaseModel, PathKeyResolverMixin):
+            feature_a: bool = Field(default=False)
+            feature_b: bool = Field(default=False)
+
+        class ChildWithFeatures(BaseModel, PathKeyResolverMixin):
+            db: DatabaseConfigModel
+            features: FeaturesModel
+
+        class ParentModel(BaseModel, PathKeyResolverMixin):
+            name: str = Field(default="default_name")
+            version: str = Field(default="0.0")
+            enabled: bool = Field(default=False)
+            child: ChildWithFeatures
+
+        parent_config = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG",
+            "child": {
+                "db": {"ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG", "ccflow_keys": "database"},
+                "features": {"ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG", "ccflow_keys": "features"},
+            },
+        }
+
+        model = ParentModel(**parent_config)
+
+        # Parent resolved from SIMPLE_CONFIG
+        assert model.name == "test_model"
+        assert model.version == "1.0"
+        assert model.enabled is True
+
+        # Child nested models resolved correctly
+        assert model.child.db.host == "localhost"
+        assert model.child.db.port == 5432
+        assert model.child.db.name == "test_db"
+        assert model.child.features.feature_a is True
+        assert model.child.features.feature_b is False
+
+    def test_plain_child_with_path_raises(self):
+        """Non-mixin nested models should not accept 'path'/'key' and must raise."""
+
+        class PlainDatabaseConfig(BaseModel):
+            host: str = Field(default="localhost")
+            port: int = Field(default=5432)
+            name: str = Field(default="default_db")
+
+        class ParentModel(BaseModel, PathKeyResolverMixin):
+            name: str = Field(default="default_name")
+            version: str = Field(default="0.0")
+            enabled: bool = Field(default=False)
+            plain_child: PlainDatabaseConfig
+
+        parent_config = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG",
+            "plain_child": {"ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG", "ccflow_keys": "database"},
+        }
+        with pytest.raises(ValidationError):
+            ParentModel(**parent_config)
+
+    def test_ccflow_merge_explicit_wins(self):
+        class Model(BaseModel, PathKeyResolverMixin):
+            a: str = Field(default="x")
+            b: int = Field(default=0)
+
+        cfg = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG",
+            "ccflow_merge": "explicit_wins",
+            "a": "explicit",
+        }
+        m = Model(**cfg)
+        # 'a' stays explicit, 'b' filled from resolved if present, else default
+        assert m.a == "explicit"
+        assert m.b == 0  # 'b' not in SIMPLE_CONFIG, so default used
+
+    def test_ccflow_keys_list_traversal(self):
+        class EnvDB(BaseModel, PathKeyResolverMixin):
+            host: str
+            port: int
+
+        cfg = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.COMPLEX_CONFIG",
+            "ccflow_keys": ["environments", "dev", "database"],
+        }
+        m = EnvDB(**cfg)
+        assert m.host == "dev.example.com"
+        assert m.port == 5432
+
+    def test_ccflow_keys_top_level_int(self):
+        class Server(BaseModel, PathKeyResolverMixin):
+            host: str
+            port: int
+
+        cfg = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SERVERS",
+            "ccflow_keys": 1,  # select second server by index
+        }
+        s = Server(**cfg)
+        assert s.host == "server2.local"
+        assert s.port == 2222
+
+    def test_ccflow_namespaced_dict_prefixed_keys(self):
+        class DB(BaseModel, PathKeyResolverMixin):
+            host: str
+            port: int
+
+        cfg = {
+            "ccflow": {
+                "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG",
+                "ccflow_keys": "database",
+                "ccflow_merge": "explicit_wins",
+                "ccflow_filter_extras": True,
+            }
+        }
+        m = DB(**cfg)
+        assert m.host == "localhost"
+        assert m.port == 5432
+
+    def test_ccflow_merge_raise_on_conflict(self):
+        class Model(BaseModel, PathKeyResolverMixin):
+            name: str
+            version: str
+            enabled: bool
+
+        cfg_ok = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG",
+            "ccflow_merge": "raise_on_conflict",
+            "name": "test_model",  # same as resolved
+        }
+        m = Model(**cfg_ok)
+        assert m.name == "test_model"
+        assert m.version == "1.0"
+        assert m.enabled is True
+
+        cfg_conflict = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG",
+            "ccflow_merge": "raise_on_conflict",
+            "version": "9.9",  # conflicts with resolved "1.0"
+        }
+        with pytest.raises(ValueError):
+            Model(**cfg_conflict)
+
+    def test_ccflow_allowed_prefixes_enforced(self):
+        class StrictDB(BaseModel, PathKeyResolverMixin):
+            host: str
+            port: int
+
+            # Restrict to our test data module
+            ccflow_allowed_prefixes: ClassVar[List[str]] = ["ccflow.tests.data.path_key_resolver_samples"]
+
+        # Allowed path
+        ok = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG",
+            "ccflow_keys": "database",
+        }
+        m = StrictDB(**ok)
+        assert m.host == "localhost"
+        assert m.port == 5432
+
+        # Disallowed path: valid import path but outside allowed prefix
+        bad = {
+            "ccflow_path": "ccflow.tests.utils.test_mixin.MixinSimpleModel",
+            "ccflow_keys": [],
+        }
+        with pytest.raises(ValueError) as ei:
+            StrictDB(**bad)
+        assert "not allowed by allowed prefixes" in str(ei.value)
+
+    def test_ccflow_debug_metadata(self):
+        class DB(BaseModel, PathKeyResolverMixin):
+            host: str
+            port: int
+
+        cfg = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG",
+            "ccflow_keys": "database",
+            "ccflow_merge": "explicit_wins",
+        }
+        m = DB(**cfg)
+        assert hasattr(m, "__ccflow_source__")
+        meta = m.__ccflow_source__
+        assert meta["path"].endswith("path_key_resolver_samples.NESTED_CONFIG")
+        assert meta["keys"] == ["database"]
+        assert meta["merge"] == "explicit_wins"
+
+    def test_mapping_with_pydantic_instance_value(self):
+        class Outer(BaseModel, PathKeyResolverMixin):
+            sub: _InnerBM
+
+        cfg = {
+            "ccflow_path": "ccflow.tests.utils.test_mixin.LOCAL_COMPLEX_WITH_BM",
+        }
+        o = Outer(**cfg)
+        assert isinstance(o.sub, _InnerBM)
+        assert o.sub.val == 5
+
+    def test_traverse_to_pydantic_model_node(self):
+        class Target(BaseModel, PathKeyResolverMixin):
+            a: int
+            b: str
+
+        cfg = {
+            "ccflow_path": "ccflow.tests.utils.test_mixin.LOCAL_PM",
+            "ccflow_keys": "pm",
+        }
+        t = Target(**cfg)
+        assert t.a == 1
+        assert t.b == "x"
+
+    def test_private_attr_is_per_instance(self):
+        class DB(BaseModel, PathKeyResolverMixin):
+            host: str
+            port: int
+
+        cfg1 = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG",
+            "ccflow_keys": "database",
+        }
+        cfg2 = {
+            "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.OTHER_NESTED_CONFIG",
+            "ccflow_keys": "database_alt",
+        }
+
+        m1 = DB(**cfg1)
+        m2 = DB(**cfg2)
+
+        assert hasattr(m1, "__ccflow_source__") and hasattr(m2, "__ccflow_source__")
+        # Metadata differs per instance
+        assert m1.__ccflow_source__["keys"] == ["database"]
+        assert m2.__ccflow_source__["keys"] == ["database_alt"]
+
+        # Mutating one should not affect the other
+        m1.__ccflow_source__["mut"] = 1
+        assert "mut" not in m2.__ccflow_source__

--- a/ccflow/tests/utils/test_mixin_hydra.py
+++ b/ccflow/tests/utils/test_mixin_hydra.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from ccflow.base import load_config as load_registry
+
+
+def test_hydra_mixin_loading():
+    root_config_dir = str(Path(__file__).resolve().parent.parent / "config")
+    # Load the dedicated mixin config file
+    r = load_registry(
+        root_config_dir=root_config_dir, root_config_name="conf_mixin", overwrite=True, basepath=str(Path(__file__).resolve().parent.parent)
+    )
+    try:
+        assert "mixin_simple" in r.models
+        assert "mixin_db" in r.models
+        assert "mixin_parent" in r.models
+
+        ms = r["mixin_simple"]
+        assert ms.name == "test_model"
+        assert ms.version == "1.0"
+        assert ms.enabled is True
+
+        md = r["mixin_db"]
+        assert md.host == "localhost"
+        assert md.port == 5432
+        assert md.name == "test_db"
+
+        mp = r["mixin_parent"]
+        # Parent resolved from SIMPLE_CONFIG
+        assert mp.name == "test_model"
+        assert mp.version == "1.0"
+        assert mp.enabled is True
+        # Child resolved via path/key
+        assert mp.child.host == "localhost"
+        assert mp.child.port == 5432
+        assert mp.child.name == "test_db"
+        # Plain child uses provided explicit values
+        assert mp.plain_child.host == "plain.example.com"
+        assert mp.plain_child.port == 3306
+        assert mp.plain_child.name == "plain_db"
+    finally:
+        r.clear()
+
+
+def test_hydra_mixin_override_path_only():
+    root_config_dir = str(Path(__file__).resolve().parent.parent / "config")
+    overrides = [
+        "mixin_db.ccflow_path=ccflow.tests.data.path_key_resolver_samples.OTHER_NESTED_CONFIG",
+    ]
+    r = load_registry(
+        root_config_dir=root_config_dir,
+        root_config_name="conf_mixin",
+        overrides=overrides,
+        overwrite=True,
+        basepath=str(Path(__file__).resolve().parent.parent),
+    )
+    try:
+        md = r["mixin_db"]
+        # Should resolve from OTHER_NESTED_CONFIG["database"]
+        assert md.host == "override.local"
+        assert md.port == 6543
+        assert md.name == "other_db"
+    finally:
+        r.clear()
+
+
+def test_hydra_mixin_override_path_and_key():
+    root_config_dir = str(Path(__file__).resolve().parent.parent / "config")
+    overrides = [
+        "mixin_db.ccflow_path=ccflow.tests.data.path_key_resolver_samples.OTHER_NESTED_CONFIG",
+        "mixin_db.ccflow_keys=database_alt",
+    ]
+    r = load_registry(
+        root_config_dir=root_config_dir,
+        root_config_name="conf_mixin",
+        overrides=overrides,
+        overwrite=True,
+        basepath=str(Path(__file__).resolve().parent.parent),
+    )
+    try:
+        md = r["mixin_db"]
+        # Should resolve from OTHER_NESTED_CONFIG["database_alt"]
+        assert md.host == "alt.local"
+        assert md.port == 7777
+        assert md.name == "alt_db"
+    finally:
+        r.clear()

--- a/ccflow/tests/utils/test_path_resolve_spec.py
+++ b/ccflow/tests/utils/test_path_resolve_spec.py
@@ -1,0 +1,130 @@
+from dataclasses import dataclass
+from typing import Mapping
+
+import pytest
+from pydantic import BaseModel as PydanticBaseModel
+
+from ccflow.utils import PathResolveSpec
+
+NESTED_PATH = "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG"
+
+
+def test_extract_from_values_top_level():
+    values = {
+        "ccflow_path": NESTED_PATH,
+        "ccflow_keys": "database",
+        "ccflow_merge": "explicit_wins",
+        "ccflow_filter_extras": True,
+        "foo": 1,
+    }
+
+    spec, mutated = PathResolveSpec.extract_from_values(values)
+    assert spec is not None
+    assert str(spec.path).endswith("path_key_resolver_samples.NESTED_CONFIG")
+    assert spec.keys == "database"
+    assert spec.merge == "explicit_wins"
+    assert spec.filter_extras is True
+    # ccflow_* keys are popped from the mutated dict
+    assert "ccflow_path" not in mutated
+    assert mutated["foo"] == 1
+
+
+def test_extract_from_values_namespaced_prefixed():
+    values = {
+        "ccflow": {
+            "ccflow_path": NESTED_PATH,
+            "ccflow_keys": "database",
+            "ccflow_merge": "resolved_wins",
+            "ccflow_filter_extras": False,
+        },
+        "bar": 2,
+    }
+
+    spec, mutated = PathResolveSpec.extract_from_values(values)
+    assert spec is not None
+    assert spec.filter_extras is False
+    assert mutated["bar"] == 2
+    assert "ccflow" not in mutated
+
+
+def test_resolve_traverse_as_mapping_allowed_prefix():
+    spec = PathResolveSpec.model_validate({"path": NESTED_PATH, "keys": "database"})
+    obj = spec.resolve_object(allowed_prefixes=["ccflow.tests.data.path_key_resolver_samples"])
+    node = spec.traverse(obj)
+    mapping = spec.as_mapping(node)
+    assert isinstance(mapping, Mapping)
+    assert mapping["host"] == "localhost"
+    assert mapping["port"] == 5432
+
+
+def test_resolve_object_disallowed_prefix_raises():
+    spec = PathResolveSpec.model_validate({"path": NESTED_PATH})
+    with pytest.raises(ValueError):
+        spec.resolve_object(allowed_prefixes=["some.other.module"])
+
+
+def test_filter_extras_map_true_and_false():
+    spec = PathResolveSpec.model_validate({"path": NESTED_PATH, "keys": "database", "filter_extras": True})
+    mapping = {"host": "localhost", "port": 5432, "extra": 1}
+    fields = {"host": None, "port": None}  # Only allow these keys
+    filtered = spec.filter_extras_map(mapping, fields)
+    assert filtered == {"host": "localhost", "port": 5432}
+
+    spec2 = PathResolveSpec.model_validate({"path": NESTED_PATH, "keys": "database", "filter_extras": False})
+    filtered2 = spec2.filter_extras_map(mapping, fields)
+    assert filtered2 == mapping
+
+
+def test_merge_into_resolved_wins_and_explicit_wins():
+    mapping = {"host": "localhost", "port": 5432}
+    values = {"host": "explicit"}
+
+    spec_resolved = PathResolveSpec.model_validate({"path": NESTED_PATH, "merge": "resolved_wins"})
+    out_resolved = spec_resolved.merge_into(values, mapping)
+    assert out_resolved["host"] == "localhost"
+    assert out_resolved["port"] == 5432
+
+    spec_explicit = PathResolveSpec.model_validate({"path": NESTED_PATH, "merge": "explicit_wins"})
+    out_explicit = spec_explicit.merge_into(values, mapping)
+    assert out_explicit["host"] == "explicit"
+    assert out_explicit["port"] == 5432
+
+
+def test_merge_into_raise_on_conflict():
+    mapping = {"host": "localhost", "port": 5432}
+    values_conflict = {"host": "explicit"}
+    spec_conflict = PathResolveSpec.model_validate({"path": NESTED_PATH, "merge": "raise_on_conflict"})
+    with pytest.raises(ValueError):
+        spec_conflict.merge_into(values_conflict, mapping)
+
+    values_no_conflict = {"name": "x"}
+    out = spec_conflict.merge_into(values_no_conflict, mapping)
+    assert out["port"] == 5432
+    assert out["host"] == "localhost"
+
+
+def test_as_mapping_with_pydantic_and_dataclass():
+    class PModel(PydanticBaseModel):
+        a: int
+        b: str
+
+    @dataclass
+    class DModel:
+        a: int
+        b: str
+
+    pm = PModel(a=1, b="x")
+    dm = DModel(a=2, b="y")
+    m1 = PathResolveSpec.as_mapping(pm)
+    m2 = PathResolveSpec.as_mapping(dm)
+    assert m1 == {"a": 1, "b": "x"}
+    assert m2 == {"a": 2, "b": "y"}
+
+
+def test_debug_meta():
+    spec = PathResolveSpec.model_validate({"path": NESTED_PATH, "keys": ["database"], "merge": "explicit_wins", "filter_extras": True})
+    meta = spec.debug_meta()
+    assert meta["path"].endswith("path_key_resolver_samples.NESTED_CONFIG")
+    assert meta["keys"] == ["database"]
+    assert meta["merge"] == "explicit_wins"
+    assert meta["filter_extras"] is True

--- a/ccflow/utils/__init__.py
+++ b/ccflow/utils/__init__.py
@@ -1,4 +1,6 @@
 from .chunker import *
 from .core import *
 from .logging import *
+from .mixin import *
+from .path_resolve_spec import PathResolveSpec
 from .tokenize import normalize_token, tokenize

--- a/ccflow/utils/mixin.py
+++ b/ccflow/utils/mixin.py
@@ -1,0 +1,53 @@
+from typing import ClassVar, List, Optional
+
+from pydantic import PrivateAttr, model_validator
+
+from .path_resolve_spec import PathResolveSpec
+
+__all__ = ("PathKeyResolverMixin",)
+
+
+class PathKeyResolverMixin:
+    """Resolve configuration values from a python-import path with optional nested key traversal.
+
+    Supported fields (either top-level or within a `ccflow` dict):
+      - `ccflow_path`: import path string (coerced to PyObjectPath)
+      - `ccflow_keys`: list[str|int] or dotted string for nested traversal (supports list indices)
+      - `ccflow_merge`: one of {"resolved_wins", "explicit_wins", "raise_on_conflict"}
+      - `ccflow_filter_extras`: bool; default True; drop resolved keys not present on the model
+
+    Optional: subclasses may set `ccflow_allowed_prefixes` to restrict import paths.
+      - `ccflow_allowed_prefixes` is a ClassVar[List[str]] of allowed import-path prefixes. If set, any
+        `ccflow_path` not starting with one of these prefixes raises a ValueError during validation.
+        This provides a lightweight allowlist to constrain dynamic imports in configs.
+    """
+
+    ccflow_allowed_prefixes: ClassVar[Optional[List[str]]] = None
+    __ccflow_source__: dict = PrivateAttr(default_factory=dict)
+
+    @model_validator(mode="wrap")
+    def _resolve_and_attach(cls, v, handler):
+        # Only operate on dict inputs; otherwise construct directly
+        values = v
+        spec: Optional[PathResolveSpec] = None
+        if isinstance(values, dict):
+            spec, values = PathResolveSpec.extract_from_values(values)
+
+        # If we have a spec, resolve and merge before constructing the instance
+        if spec is not None:
+            obj = spec.resolve_object(allowed_prefixes=cls.ccflow_allowed_prefixes)
+            node = spec.traverse(obj)
+            mapping = spec.as_mapping(node)
+            mapping = spec.filter_extras_map(mapping, getattr(cls, "model_fields", {}))
+            values = spec.merge_into(values, mapping)
+
+        # Construct instance
+        result = handler(values)
+
+        # Attach debug metadata if spec was provided
+        if isinstance(result, object) and spec is not None:
+            try:
+                result.__ccflow_source__ = spec.debug_meta()
+            except Exception:
+                pass
+        return result

--- a/ccflow/utils/path_resolve_spec.py
+++ b/ccflow/utils/path_resolve_spec.py
@@ -1,0 +1,160 @@
+from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple, Union
+
+from pydantic import AliasChoices, BaseModel as PydanticModel, Field
+
+from ccflow import PyObjectPath
+
+
+class PathResolveSpec(PydanticModel):
+    """Specification for ccflow path/key resolution.
+
+    - path: Import path or PyObjectPath to a resolvable object
+    - keys: Nested traversal keys (list or dotted string)
+    - merge: Merge strategy ('resolved_wins', 'explicit_wins', 'raise_on_conflict')
+    - filter_extras: Whether to drop keys not present on the target model
+    """
+
+    # Accept both short names and ccflow_* variants via validation aliases
+    path: PyObjectPath = Field(
+        validation_alias=AliasChoices("path", "ccflow_path"),
+        description="Python import path (coerced to PyObjectPath) to a mapping-like object or container for traversal.",
+    )
+    keys: Optional[Union[str, int, List[Union[str, int]]]] = Field(
+        default=None,
+        validation_alias=AliasChoices("keys", "ccflow_keys"),
+        description="Nested traversal keys (str/int or list). Dotted strings are allowed (e.g., 'a.b.0.c').",
+    )
+    merge: Literal["resolved_wins", "explicit_wins", "raise_on_conflict"] = Field(
+        default="resolved_wins",
+        validation_alias=AliasChoices("merge", "ccflow_merge"),
+        description="Merge strategy: 'resolved_wins' (resolved overrides explicit), 'explicit_wins' (explicit overrides resolved), or 'raise_on_conflict' (error if both define different values).",
+    )
+    filter_extras: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("filter_extras", "ccflow_filter_extras"),
+        description="Whether to drop keys from the resolved mapping that are not fields of the target model.",
+    )
+
+    @classmethod
+    def extract_from_values(cls, values: Dict[str, Any]) -> Tuple[Optional["PathResolveSpec"], Dict[str, Any]]:
+        """Extract spec from incoming values and pop ccflow hints. Returns (spec|None, mutated_values)."""
+        if not isinstance(values, dict):
+            return None, values
+
+        spec_input: Dict[str, Any] = {}
+        if "ccflow" in values and isinstance(values["ccflow"], dict):
+            spec_input = values.pop("ccflow")
+        else:
+            if "ccflow_path" in values:
+                spec_input["path"] = values.pop("ccflow_path")
+            if "ccflow_keys" in values:
+                spec_input["keys"] = values.pop("ccflow_keys")
+            if "ccflow_merge" in values:
+                spec_input["merge"] = values.pop("ccflow_merge")
+            if "ccflow_filter_extras" in values:
+                spec_input["filter_extras"] = values.pop("ccflow_filter_extras")
+
+        if not spec_input:
+            return None, values
+
+        spec = cls.model_validate(spec_input)
+        return spec, values
+
+    @staticmethod
+    def _normalize_keys(keys: Any) -> List[Any]:
+        if keys is None:
+            return []
+        if isinstance(keys, int):
+            return [keys]
+        if isinstance(keys, str):
+            parts = [p for p in keys.split(".") if p != ""]
+            out: List[Any] = []
+            for p in parts:
+                if p.isdigit():
+                    out.append(int(p))
+                else:
+                    out.append(p)
+            return out
+        if isinstance(keys, (list, tuple)):
+            out: List[Any] = []
+            for p in keys:
+                if isinstance(p, str) and p.isdigit():
+                    out.append(int(p))
+                else:
+                    out.append(p)
+            return out
+        return [keys]
+
+    def resolve_object(self, *, allowed_prefixes: Optional[List[str]] = None) -> Any:
+        if isinstance(self.path, str) and not self.path.strip():
+            raise ValueError("ccflow_path cannot be empty")
+        path_str = str(self.path)
+        if allowed_prefixes and not any(path_str.startswith(prefix) for prefix in allowed_prefixes):
+            raise ValueError(f"ccflow_path '{path_str}' not allowed by allowed prefixes: {allowed_prefixes}")
+        return self.path.object
+
+    def traverse(self, obj: Any) -> Any:
+        keys = self._normalize_keys(self.keys)
+        cur = obj
+        for k in keys:
+            if isinstance(cur, dict):
+                if k not in cur:
+                    raise KeyError(f"Key '{k}' not found while traversing ccflow_keys={keys}. Available keys: {list(cur.keys())}")
+                cur = cur[k]
+            elif isinstance(cur, (list, tuple)):
+                if not isinstance(k, int):
+                    raise KeyError(f"Expected integer index while traversing a list, got key='{k}'")
+                try:
+                    cur = cur[k]
+                except IndexError:
+                    raise KeyError(f"List index out of range: {k} while traversing ccflow_keys={keys}")
+            else:
+                raise KeyError(f"Cannot traverse into type {type(cur).__name__} with key '{k}'")
+        return cur
+
+    @staticmethod
+    def as_mapping(obj: Any) -> Mapping[str, Any]:
+        from dataclasses import asdict, is_dataclass
+
+        if isinstance(obj, dict):
+            return obj
+        if isinstance(obj, PydanticModel):
+            return obj.model_dump()
+        if is_dataclass(obj):
+            return asdict(obj)
+        raise ValueError("Resolved object is not a mapping and cannot be converted for ccflow_path resolution")
+
+    def filter_extras_map(self, mapping: Mapping[str, Any], fields: Mapping[str, Any]) -> Dict[str, Any]:
+        if not self.filter_extras:
+            return dict(mapping)
+        allowed = fields.keys()
+        return {k: v for k, v in mapping.items() if k in allowed}
+
+    def merge_into(self, values: Dict[str, Any], mapping: Mapping[str, Any]) -> Dict[str, Any]:
+        if self.merge not in ("resolved_wins", "explicit_wins", "raise_on_conflict"):
+            raise ValueError("ccflow_merge must be one of {'resolved_wins','explicit_wins','raise_on_conflict'}")
+        values = dict(values)
+        if self.merge == "resolved_wins":
+            values.update(mapping)
+            return values
+        elif self.merge == "explicit_wins":
+            for k, v in mapping.items():
+                if k not in values:
+                    values[k] = v
+            return values
+        else:
+            conflicts = [k for k, v in mapping.items() if k in values and values[k] != v]
+            if conflicts:
+                raise ValueError(f"ccflow_merge=raise_on_conflict detected conflicting keys: {conflicts}")
+            for k, v in mapping.items():
+                if k not in values:
+                    values[k] = v
+            return values
+
+    def debug_meta(self) -> Dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "keys": self._normalize_keys(self.keys),
+            "merge": self.merge,
+            "filter_extras": self.filter_extras,
+        }

--- a/docs/wiki/PathKeyResolverMixin.md
+++ b/docs/wiki/PathKeyResolverMixin.md
@@ -1,0 +1,154 @@
+# PathKeyResolverMixin
+
+The `PathKeyResolverMixin` enables models to populate their fields from a Python-importable object (e.g., a module-level dictionary), optionally traversing nested keys and controlling merge precedence.
+
+Key Concepts
+
+- `ccflow_path`: Import path string (or `PyObjectPath`) to an object that can be converted to a mapping.
+- `ccflow_keys`: List of keys (strings and/or integer indexes) or a dotted string for nested traversal.
+- `ccflow_merge`: Merge strategy; one of `resolved_wins` (default), `explicit_wins`, or `raise_on_conflict`.
+- `ccflow_filter_extras`: Boolean; default `true`. If true, drops keys from the resolved mapping that are not model fields.
+- Optional: subclasses may set `ccflow_allowed_prefixes: ClassVar[List[str]]` to restrict allowed import path prefixes.
+
+Usage (Python)
+
+```python
+from pydantic import Field
+from ccflow import BaseModel, PathKeyResolverMixin
+
+class DBConfig(BaseModel, PathKeyResolverMixin):
+    host: str
+    port: int
+
+cfg = {
+    "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG",
+    "ccflow_keys": "database",  # or ["database"]
+}
+db = DBConfig(**cfg)
+assert db.host == "localhost"
+assert db.port == 5432
+```
+
+Deep Traversal
+
+```python
+cfg = {
+    "ccflow_path": "ccflow.tests.data.path_key_resolver_samples.COMPLEX_CONFIG",
+    "ccflow_keys": ["environments", "dev", "database"],
+}
+```
+
+Merge Strategies
+
+- `resolved_wins`: values from the resolved mapping override explicitly provided values.
+- `explicit_wins`: explicitly provided values override resolved ones; resolved values fill only missing fields.
+- `raise_on_conflict`: raises `ValueError` if both resolved and explicit inputs define the same field with different values; otherwise fills missing fields.
+
+```python
+class Model(BaseModel, PathKeyResolverMixin):
+    a: str = Field("x")
+    b: int = Field(0)
+
+m = Model(
+    ccflow_path="ccflow.tests.data.path_key_resolver_samples.SIMPLE_CONFIG",
+    ccflow_merge="explicit_wins",
+    a="explicit",
+)
+assert m.a == "explicit"
+```
+
+Hydra Config Example
+
+```yaml
+mixin_db:
+  _target_: mypkg.DBConfig
+  ccflow_path: ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG
+  ccflow_keys: database
+```
+
+Hydra Overrides
+
+```text
+mixin_db.ccflow_path=ccflow.tests.data.path_key_resolver_samples.OTHER_NESTED_CONFIG
+mixin_db.ccflow_keys=database_alt
+```
+
+Error Handling
+
+- Empty `ccflow_path` raises `ValueError`.
+- Key traversal errors raise `KeyError` with the full traversal path and available keys at the failure point.
+- Non-mapping objects raise a `ValueError` unless they are pydantic models or dataclasses (which are converted).
+
+Namespaced Spec
+
+- You can specify all options under a single `ccflow` dictionary. This makes configs cleaner and self-documenting.
+
+```yaml
+db:
+  _target_: mypkg.DBConfig
+  ccflow:
+    path: ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG
+    keys: database
+    merge: resolved_wins
+    filter_extras: true
+```
+
+Debug Metadata
+
+- Instances using the mixin include `__ccflow_source__` as a private attribute with `{path, keys, merge, filter_extras}` for auditability.
+
+Extras Filtering
+
+- By default, keys not present on the model are dropped from the resolved mapping to avoid `extra_forbidden` errors.
+- Set `ccflow_filter_extras: false` to allow all resolved keys (models may need `model_config = ConfigDict(extra="ignore")`).
+
+Motivation
+
+- Hydra-centric projects benefit from keeping most configuration in YAML, but some defaults are better expressed in Python (shared dicts, computed values, or tightly coupled settings).
+- Referencing Python code allows:
+  - Centralizing canonical configs used across modules, tests, and examples.
+  - Environment- or context-specific defaults by selecting different objects via `ccflow_keys`.
+  - Avoiding duplication across multiple YAML files; update once in code and reuse.
+  - Type-checked evolution: the spec is validated, and tests can guard behavior.
+- Merge strategies (`resolved_wins`, `explicit_wins`, `raise_on_conflict`) make precedence explicit, not implicit.
+- Optional allowlist (`ccflow_allowed_prefixes`) keeps imports constrained to known-safe modules.
+
+Example: Python-backed defaults with Hydra
+
+- Define Python configs in a module like `ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG`.
+- Select per environment in YAML with `ccflow_keys: database` or `ccflow_keys: database_alt`.
+- Override dynamically at runtime:
+  - `mixin_db.ccflow_path=ccflow.tests.data.path_key_resolver_samples.OTHER_NESTED_CONFIG`
+  - `mixin_db.ccflow_keys=database_alt`
+
+Allowlist Prefixes
+
+- You can restrict dynamic import paths via a class-level allowlist.
+- Define `ccflow_allowed_prefixes: ClassVar[List[str]]` on your model to constrain which modules may be referenced by `ccflow_path`.
+
+```python
+from typing import ClassVar, List
+from ccflow import BaseModel, PathKeyResolverMixin
+
+class StrictDB(BaseModel, PathKeyResolverMixin):
+    host: str
+    port: int
+
+    # Only allow imports under our test data module
+    ccflow_allowed_prefixes: ClassVar[List[str]] = ["ccflow.tests.data.path_key_resolver_samples"]
+
+# Allowed
+StrictDB(
+    ccflow_path="ccflow.tests.data.path_key_resolver_samples.NESTED_CONFIG",
+    ccflow_keys="database",
+)
+
+# Disallowed: valid import, but outside the allowed prefix
+StrictDB(
+    ccflow_path="ccflow.tests.utils.test_mixin.MixinSimpleModel",
+    ccflow_keys=[],
+)  # raises ValueError: not allowed by allowed prefixes
+```
+
+- The check uses `str(ccflow_path).startswith(prefix)` for each prefix.
+- Leave `ccflow_allowed_prefixes` unset (None) to allow any import path.


### PR DESCRIPTION
Add `PathKeyResolverMixin` which allows specifying some key/value pairs from python code via a `PyObjectPath`. This allows offloading some of the configuration to python, getting benefits from:
easier testability, cohesiveness of related configurations, and deduplication. 

This functionality is opt-in, since base `ccflow.BaseModel` classes do not inherit from it via default.