### PR TITLE
Validate DateRangeContext from DateContext

### DIFF
--- a/ccflow/context.py
+++ b/ccflow/context.py
@@ -147,6 +147,12 @@ class DateRangeContext(ContextBase):
     _normalize_start = field_validator("start_date", mode="before")(normalize_date)
     _normalize_end = field_validator("end_date", mode="before")(normalize_date)
 
+    @model_validator(mode="wrap")
+    def _date_context_validator(cls, v, handler, info):
+        if isinstance(v, DateContext):
+            v = dict(start_date=v.date, end_date=v.date)
+        return handler(v)
+
 
 class DatetimeRangeContext(ContextBase):
     start_datetime: datetime

--- a/ccflow/tests/test_context.py
+++ b/ccflow/tests/test_context.py
@@ -96,6 +96,11 @@ class TestContexts(TestCase):
         self.assertEqual(TypeAdapter(DateRangeContext).validate_python(["-1d", "0d"]), c)
         self.assertEqual(TypeAdapter(DateRangeContext).validate_python(["-1d", datetime.now()]), c)
 
+    def test_date_range_from_date(self):
+        # Test validation from a DateContext
+        d0 = date.today()
+        self.assertEqual(TypeAdapter(DateRangeContext).validate_python(DateContext(date=d0)), DateRangeContext(start_date=d0, end_date=d0))
+
     def test_freq(self):
         self.assertEqual(
             FreqDateContext.model_validate("5min,2022-01-01"),


### PR DESCRIPTION
It won't do a "double validation", i.e. `{"date":d} -> DateContext(date=d) -> DateRangeContext(start_date=d, end_date=d)`
However, the single validation is helpful if a model that takes a `DateContext` wants to seamlessly call one that takes a `DateRangeContext`. We can revisit later if needed.