### PR TITLE
fix: lazy-import panel in ccflow.utils.hydra

### DIFF
--- a/ccflow/utils/hydra.py
+++ b/ccflow/utils/hydra.py
@@ -11,11 +11,6 @@ from typing import Any, Callable, Dict, List, Optional
 from hydra._internal.defaults_list import DefaultsList
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
-try:
-    import panel as pn
-except ImportError:
-    pn = None
-
 from ..base import ModelRegistry
 from ..callable import FlowOptions, FlowOptionsOverride
 
@@ -412,7 +407,9 @@ def get_args_parser_default_ui() -> argparse.ArgumentParser:
 
 
 def ui_launcher_default(cfg, **kwargs):
-    if pn is None:
+    try:
+        import panel as pn
+    except ImportError:
         raise ImportError("Panel is not installed. Please install panel to use the UI.")
     pn.extension()
     pn.extension("jsoneditor")
@@ -461,10 +458,11 @@ def cfg_explain_cli(
         pprint(merged_cfg, width=120, indent=2)
     elif ui_launcher is not None:
         ui_launcher(merged_cfg, **vars(args))
-    elif pn is not None:
-        ui_launcher_default(merged_cfg, **vars(args))
     else:
-        raise ValueError("Cannot launch UI, no ui_launcher provided and/or panel not installed. Use --no-gui to print the results.")
+        try:
+            ui_launcher_default(merged_cfg, **vars(args))
+        except ImportError:
+            raise ValueError("Cannot launch UI, no ui_launcher provided and/or panel not installed. Use --no-gui to print the results.")
 
 
 def _load_model_registry(cfg: DictConfig):


### PR DESCRIPTION
## Problem
`ccflow/utils/hydra.py` imports `panel as pn` at module level, which impacts import time for anything using the ccflow hydra tools — even when the panel UI functionality is never used.

## Solution
Move `import panel as pn` from the top-level `try/except` block into `ui_launcher_default()`, the only function that uses it. This follows the same lazy-import pattern already used in `ccflow/base.py`.

## Changes
- Removed top-level `try: import panel as pn / except ImportError: pn = None`
- Added local `import panel as pn` inside `ui_launcher_default()` with `ImportError` handling
- Updated `cfg_explain_cli()` to use `try/except ImportError` around `ui_launcher_default()` instead of the old `pn is not None` check

## Testing
- All 653 tests pass (2 skipped)
- Verified `import ccflow.utils.hydra` no longer triggers a panel import