### PR TITLE
feat: Add resolve_from parameter to ModelRegistry.load_config

### DIFF
--- a/ccflow/base.py
+++ b/ccflow/base.py
@@ -561,6 +561,7 @@ class ModelRegistry(BaseModel, collections.abc.Mapping):
         cfg: DictConfig,
         overwrite: bool = False,
         skip_exceptions: bool = False,
+        resolve_from: Optional["ModelRegistry"] = None,
     ) -> Self:
         """Load from OmegaConf DictConfig that follows hydra conventions.
 
@@ -568,9 +569,11 @@ class ModelRegistry(BaseModel, collections.abc.Mapping):
             cfg: An OmegaConf DictConfig
             overwrite: Whether to allow overwriting of names that already exist
             skip_exceptions: Whether to skip any exceptions that are thrown when validating and registering models
+            resolve_from: An optional registry to use as the root for resolving absolute paths. When provided,
+                absolute paths (starting with ``/``) resolve from this registry instead of from ``self``.
         """
         loader = _ModelRegistryLoader(overwrite=overwrite)
-        return loader.load_config(cfg, self, skip_exceptions=skip_exceptions)
+        return loader.load_config(cfg, self, skip_exceptions=skip_exceptions, resolve_from=resolve_from)
 
     def create_config_from_path(
         self,
@@ -667,7 +670,9 @@ class _ModelRegistryLoader:
 
         return models_to_register
 
-    def load_config(self, cfg: DictConfig, registry: ModelRegistry, skip_exceptions: bool = False) -> ModelRegistry:
+    def load_config(
+        self, cfg: DictConfig, registry: ModelRegistry, skip_exceptions: bool = False, resolve_from: Optional[ModelRegistry] = None
+    ) -> ModelRegistry:
         """Load from OmegaConf DictConfig that follows hydra conventions."""
         # Here we use hydra's 'instantiate' to instantiate models,
         # because it provides a standard way to resolve the class name
@@ -678,7 +683,11 @@ class _ModelRegistryLoader:
         from hydra.errors import InstantiationException
         from hydra.utils import instantiate
 
-        models_to_register = self._make_subregistries(cfg, [registry])
+        if resolve_from is not None and resolve_from is not registry:
+            initial_chain = [resolve_from, registry]
+        else:
+            initial_chain = [registry]
+        models_to_register = self._make_subregistries(cfg, initial_chain)
         while True:
             unresolved_models = []
             for registries, k, v, _ in models_to_register:

--- a/ccflow/tests/test_base_registry.py
+++ b/ccflow/tests/test_base_registry.py
@@ -40,6 +40,26 @@ def my_list() -> List[str]:
     return ["i", "j"]
 
 
+def create_dynamic_subregistry(shared_model_path: str) -> ModelRegistry:
+    """Called via _target_ — dynamically creates a sub-registry with
+    models that reference both root (absolute) and local (relative) models."""
+    sub = ModelRegistry(name="dynamic")
+    cfg = {
+        "local_model": {
+            "_target_": "ccflow.tests.test_base_registry.MyTestModel",
+            "a": "local",
+            "b": 2.0,
+        },
+        "ref_model": {
+            "_target_": "ccflow.tests.test_base_registry.MyNestedModel",
+            "x": shared_model_path,
+            "y": "local_model",
+        },
+    }
+    sub.load_config(cfg, resolve_from=ModelRegistry.root())
+    return sub
+
+
 class MyNestedModel(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)  # To allow z = MyClass, even though there is no validator
 
@@ -488,6 +508,81 @@ class TestRegistryLoading(TestCase):
             r["subregistry2/baz"].get_registry_dependencies(),
             [["/subregistry1/foo"], ["/subregistry2/qux"]],
         )
+
+    def test_load_config_resolve_from(self):
+        """load_config on sub-registry resolves absolute paths via resolve_from."""
+        r = ModelRegistry.root()
+        shared = MyTestModel(a="shared", b=1.0)
+        r.add("shared_model", shared)
+
+        sub = ModelRegistry(name="sub")
+        r.add("sub", sub)
+
+        cfg = OmegaConf.create(
+            {
+                # Forward reference: ref_model defined before local_model
+                "ref_model": {
+                    "_target_": "ccflow.tests.test_base_registry.MyNestedModel",
+                    "x": "/shared_model",  # Absolute path — needs root
+                    "y": "local_model",  # Relative path — forward reference to sibling
+                },
+                "local_model": {
+                    "_target_": "ccflow.tests.test_base_registry.MyTestModel",
+                    "a": "local",
+                    "b": 2.0,
+                },
+            }
+        )
+
+        # Without resolve_from: fails because /shared_model can't resolve from sub
+        sub2 = ModelRegistry(name="sub2")
+        with self.assertRaises(InstantiationException):
+            sub2.load_config(cfg)
+
+        # With resolve_from: works
+        sub.load_config(cfg, resolve_from=r)
+        self.assertIs(sub["ref_model"].x, r["shared_model"])
+        self.assertIs(sub["ref_model"].y, sub["local_model"])
+
+    def test_load_config_resolve_from_nested_target(self):
+        """_target_ function dynamically creates a sub-registry with both
+        absolute references (to root) and relative references (to siblings)."""
+        r = ModelRegistry.root()
+        shared = MyTestModel(a="shared", b=1.0)
+        r.add("shared_model", shared)
+
+        cfg = OmegaConf.create(
+            {
+                "dynamic": {
+                    "_target_": "ccflow.tests.test_base_registry.create_dynamic_subregistry",
+                    "shared_model_path": "/shared_model",
+                }
+            }
+        )
+
+        r.load_config(cfg)
+
+        # The dynamic sub-registry was created and added to root
+        self.assertIsInstance(r["dynamic"], ModelRegistry)
+        # Absolute reference resolved from root
+        self.assertIs(r["dynamic"]["ref_model"].x, r["shared_model"])
+        # Relative reference resolved within the sub-registry
+        self.assertIs(r["dynamic"]["ref_model"].y, r["dynamic"]["local_model"])
+
+    def test_load_config_resolve_from_self_noop(self):
+        """resolve_from=self is equivalent to resolve_from=None (no-op)."""
+        r = ModelRegistry.root()
+        cfg = OmegaConf.create(
+            {
+                "foo": {
+                    "_target_": "ccflow.tests.test_base_registry.MyTestModel",
+                    "a": "test",
+                    "b": 0.0,
+                },
+            }
+        )
+        r.load_config(cfg, resolve_from=r)
+        self.assertEqual(r["foo"], MyTestModel(a="test", b=0.0))
 
 
 class TestRegistryLoadingErrors(TestCase):


### PR DESCRIPTION
## Summary

Add an optional `resolve_from` parameter to `ModelRegistry.load_config` that enables nested registry loading where sub-registries can reference models elsewhere in the tree via absolute paths.

## Problem

`ModelRegistry.load_config(cfg)` always starts the `RegistryLookupContext` chain with `[self]`. Absolute paths (e.g., `/equities/gold/close`) in `resolve_str()` use `registries[0]` for lookup, so when loading into a sub-registry, absolute paths resolve from the sub-registry — not from root. This makes dynamic sub-registry creation patterns require using private `_ModelRegistryLoader` APIs directly.

## Solution

```python
# Before: fails — /shared/data can't resolve from sub_registry
sub_registry.load_config(cfg)

# After: works — absolute paths resolve from root
sub_registry.load_config(cfg, resolve_from=ModelRegistry.root())
```

When `resolve_from` is provided, it is prepended to the initial registries chain so `registries[0]` = `resolve_from` (for absolute paths) and `registries[-1]` = `self` (for relative paths). Default `None` preserves current behavior.

## Changes

- **`ccflow/base.py`** (~6 lines): Add `resolve_from` parameter to `ModelRegistry.load_config` and `_ModelRegistryLoader.load_config`
- **`ccflow/tests/test_base_registry.py`** (3 tests + helper): Direct usage, nested `_target_` pattern, and self-noop edge case

## Backward Compatibility

Fully backward compatible — `resolve_from=None` (default) preserves existing behavior. No changes to `_make_subregistries`, `resolve_str`, or `RegistryLookupContext`.