### PR TITLE
Only pull relevant keys for caching FlowContext

### DIFF
--- a/ccflow/evaluators/common.py
+++ b/ccflow/evaluators/common.py
@@ -1,7 +1,10 @@
+import hashlib
 import itertools
 import logging
+import marshal
 import time
 from contextlib import nullcontext
+from dataclasses import dataclass
 from datetime import timedelta
 from pprint import pformat
 from types import MappingProxyType
@@ -13,6 +16,13 @@ from typing_extensions import override
 
 from ..base import BaseModel, make_lazy_result
 from ..callable import CallableModel, ContextBase, EvaluatorBase, ModelEvaluationContext, ResultType
+from ..flow_model import (
+    _callable_fingerprint,
+    _declared_model_dependencies,
+    _generated_model_instance,
+    _missing_regular_param_names,
+    _resolved_contextual_inputs,
+)
 
 __all__ = [
     "cache_key",
@@ -206,6 +216,172 @@ def cache_key(flow_obj: Union[ModelEvaluationContext, ContextBase, CallableModel
         raise TypeError(f"object of type {type(flow_obj)} cannot be serialized by this function!")
 
 
+def _callable_definition_identity(func: Any) -> str:
+    module = getattr(func, "__module__", None) or type(func).__module__
+    qualname = getattr(func, "__qualname__", None) or type(func).__qualname__
+    code = getattr(func, "__code__", None)
+    if code is None:
+        return f"callable:{module}:{qualname}"
+
+    payload = "|".join(
+        [
+            module,
+            qualname,
+            code.co_filename,
+            str(code.co_firstlineno),
+            hashlib.sha256(marshal.dumps(code)).hexdigest(),
+            repr(getattr(func, "__defaults__", None)),
+        ]
+    )
+    return f"callable:{payload}"
+
+
+def _unwrap_generated_identity_context(evaluation_context: ModelEvaluationContext) -> Optional[ModelEvaluationContext]:
+    current = evaluation_context
+    seen: Set[int] = set()
+
+    while isinstance(current.model, EvaluatorBase):
+        if id(current) in seen:
+            return None
+        seen.add(id(current))
+        if not isinstance(current.context, ModelEvaluationContext):
+            return None
+        current = current.context
+
+    return current
+
+
+def _literal_identity_value(value: Any) -> Any:
+    if callable(value):
+        return ("callable", _callable_fingerprint(value))
+    return value
+
+
+@dataclass(frozen=True)
+class _LiteralBinding:
+    name: str
+    value: Any
+
+
+@dataclass(frozen=True)
+class _ContextBinding:
+    name: str
+    value: Any
+
+
+@dataclass(frozen=True)
+class _OpaqueChildReference:
+    key: bytes
+
+
+@dataclass(frozen=True)
+class _GeneratedLocalRequest:
+    definition_id: str
+    context_type_id: str
+    fn: str
+    literal_inputs: tuple[_LiteralBinding, ...]
+    contextual_inputs: tuple[_ContextBinding, ...]
+    dependencies: tuple["_GeneratedLocalRequest | _OpaqueChildReference", ...]
+
+
+def _context_type_identity(context_type: Any) -> str:
+    return f"{getattr(context_type, '__module__', None)}:{getattr(context_type, '__qualname__', repr(context_type))}"
+
+
+def _opaque_child_reference(model: CallableModel, context: ContextBase) -> _OpaqueChildReference:
+    return _OpaqueChildReference(key=cache_key(ModelEvaluationContext(model=model, context=context)))
+
+
+def _generated_local_request(evaluation_context: ModelEvaluationContext) -> Optional[_GeneratedLocalRequest]:
+    memo: Dict[bytes, Optional[_GeneratedLocalRequest]] = {}
+    return _generated_local_request_impl(evaluation_context, memo, set())
+
+
+def _generated_local_identity_key(evaluation_context: ModelEvaluationContext) -> Optional[bytes]:
+    request = _generated_local_request(evaluation_context)
+    if request is None:
+        return None
+    return dask.base.tokenize(request).encode("utf-8")
+
+
+def _generated_local_request_impl(
+    evaluation_context: ModelEvaluationContext,
+    memo: Dict[bytes, Optional[_GeneratedLocalRequest]],
+    in_progress: Set[bytes],
+) -> Optional[_GeneratedLocalRequest]:
+    inner = _unwrap_generated_identity_context(evaluation_context)
+    if inner is None or inner.context is None:
+        return None
+
+    try:
+        memo_key = cache_key(inner)
+    except Exception:
+        return None
+
+    if memo_key in memo:
+        return memo[memo_key]
+    if memo_key in in_progress:
+        return None
+
+    generated = _generated_model_instance(inner.model)
+    if generated is None or inner.fn not in {"__call__", "__deps__"}:
+        memo[memo_key] = None
+        return None
+
+    config = type(generated).__flow_model_config__
+    if _missing_regular_param_names(generated, config):
+        memo[memo_key] = None
+        return None
+
+    in_progress.add(memo_key)
+    try:
+        try:
+            contextual_inputs = _resolved_contextual_inputs(generated, config, inner.context)
+            dependencies = _declared_model_dependencies(generated, config, inner.context, include_lazy=True)
+        except Exception:
+            memo[memo_key] = None
+            return None
+
+        literal_inputs = []
+        for param in config.regular_params:
+            value = getattr(generated, param.name)
+            if isinstance(value, CallableModel):
+                continue
+            literal_inputs.append(_LiteralBinding(name=param.name, value=_literal_identity_value(value)))
+
+        dependency_requests = []
+        for model, contexts in dependencies:
+            for context in contexts:
+                child_evaluation = ModelEvaluationContext(model=model, context=context)
+                child_request = _generated_local_request_impl(child_evaluation, memo, in_progress)
+                if child_request is None:
+                    child_request = _opaque_child_reference(model, context)
+                dependency_requests.append(child_request)
+
+        request = _GeneratedLocalRequest(
+            definition_id=_callable_definition_identity(config.func),
+            context_type_id=_context_type_identity(config.context_type),
+            fn=inner.fn,
+            literal_inputs=tuple(literal_inputs),
+            contextual_inputs=tuple(_ContextBinding(name=param.name, value=contextual_inputs[param.name]) for param in config.contextual_params),
+            dependencies=tuple(dependency_requests),
+        )
+        memo[memo_key] = request
+        return memo[memo_key]
+    except Exception:
+        memo[memo_key] = None
+        return None
+    finally:
+        in_progress.discard(memo_key)
+
+
+def _evaluation_cache_key(evaluation_context: ModelEvaluationContext) -> bytes:
+    generated_key = _generated_local_identity_key(evaluation_context)
+    if generated_key is not None:
+        return generated_key
+    return cache_key(evaluation_context)
+
+
 class MemoryCacheEvaluator(EvaluatorBase):
     """Evaluator that caches results in memory."""
 
@@ -215,7 +391,7 @@ class MemoryCacheEvaluator(EvaluatorBase):
 
     def key(self, context: ModelEvaluationContext):
         """Function to convert a ModelEvaluationContext to a key"""
-        return cache_key(context)
+        return _evaluation_cache_key(context)
 
     @property
     def cache(self):
@@ -252,7 +428,7 @@ class CallableModelGraph(BaseModel):
 
 
 def _build_dependency_graph(evaluation_context: ModelEvaluationContext, graph: CallableModelGraph, parent_key: Optional[bytes] = None):
-    key = cache_key(evaluation_context)
+    key = _evaluation_cache_key(evaluation_context)
     if parent_key:
         graph.graph[parent_key].add(key)
     if key not in graph.ids:
@@ -275,7 +451,7 @@ def get_dependency_graph(evaluation_context: ModelEvaluationContext) -> Callable
     Args:
         evaluation_context: The model and context to build the graph for.
     """
-    root_key = cache_key(evaluation_context)
+    root_key = _evaluation_cache_key(evaluation_context)
     graph = CallableModelGraph(ids={}, graph={}, root_id=root_key)
     _build_dependency_graph(evaluation_context, graph)
     return graph

--- a/ccflow/flow_model.py
+++ b/ccflow/flow_model.py
@@ -296,8 +296,8 @@ def _callable_closure_repr(transform: Any) -> str:
 
 
 def _callable_fingerprint(transform: Any) -> str:
-    module = getattr(transform, "__module__", type(transform).__module__)
-    qualname = getattr(transform, "__qualname__", type(transform).__qualname__)
+    module = getattr(transform, "__module__", None) or type(transform).__module__
+    qualname = getattr(transform, "__qualname__", None) or type(transform).__qualname__
     code = getattr(transform, "__code__", None)
     if code is None:
         return f"callable:{module}:{qualname}:{repr(transform)}"
@@ -759,23 +759,33 @@ def _make_call_impl(config: _FlowModelConfig) -> _AnyCallable:
     return __call__
 
 
+def _declared_model_dependencies(
+    model: "_GeneratedFlowModelBase",
+    config: _FlowModelConfig,
+    context: ContextBase,
+    *,
+    include_lazy: bool,
+) -> GraphDepList:
+    missing_regular = _missing_regular_param_names(model, config)
+    if missing_regular:
+        missing = ", ".join(sorted(missing_regular))
+        raise TypeError(f"Missing regular parameter(s) for {_callable_name(config.func)}: {missing}. Bind them before dependency evaluation.")
+
+    deps = []
+    for param in config.regular_params:
+        if param.is_lazy and not include_lazy:
+            continue
+        value = getattr(model, param.name, _UNSET_FLOW_INPUT)
+        if isinstance(value, BoundModel):
+            deps.append((value.model, [value._transform_context(context)]))
+        elif isinstance(value, CallableModel):
+            deps.append((value, [context]))
+    return deps
+
+
 def _make_deps_impl(config: _FlowModelConfig) -> _AnyCallable:
     def __deps__(self, context):
-        missing_regular = _missing_regular_param_names(self, config)
-        if missing_regular:
-            missing = ", ".join(sorted(missing_regular))
-            raise TypeError(f"Missing regular parameter(s) for {_callable_name(config.func)}: {missing}. Bind them before dependency evaluation.")
-
-        deps = []
-        for param in config.regular_params:
-            if param.is_lazy:
-                continue
-            value = getattr(self, param.name, _UNSET_FLOW_INPUT)
-            if isinstance(value, BoundModel):
-                deps.append((value.model, [value._transform_context(context)]))
-            elif isinstance(value, CallableModel):
-                deps.append((value, [context]))
-        return deps
+        return _declared_model_dependencies(self, config, context, include_lazy=False)
 
     cast(Any, __deps__).__signature__ = inspect.Signature(
         parameters=[

--- a/ccflow/tests/test_flow_model.py
+++ b/ccflow/tests/test_flow_model.py
@@ -1,6 +1,7 @@
 """Focused tests for the FromContext-based Flow.model API."""
 
 import graphlib
+import logging
 from datetime import date, timedelta
 from typing import Annotated
 
@@ -21,7 +22,7 @@ from ccflow import (
     Lazy,
     ModelRegistry,
 )
-from ccflow.evaluators import GraphEvaluator
+from ccflow.evaluators import GraphEvaluator, LoggingEvaluator, MemoryCacheEvaluator, MultiEvaluator, get_dependency_graph
 
 
 class SimpleContext(ContextBase):
@@ -393,6 +394,150 @@ def test_lazy_and_from_context_combination_is_rejected():
         @Flow.model
         def bad(x: Lazy[FromContext[int]]) -> int:
             return x()
+
+
+def test_generated_cache_identity_ignores_unrelated_ambient_fields():
+    calls = {"source": 0, "root": 0}
+
+    @Flow.model
+    def source(value: FromContext[int]) -> int:
+        calls["source"] += 1
+        return value * 10
+
+    @Flow.model
+    def root(x: int, penalty: FromContext[int]) -> int:
+        calls["root"] += 1
+        return x + penalty
+
+    model = root(x=source())
+    evaluator = MultiEvaluator(evaluators=[LoggingEvaluator(log_level=logging.INFO, verbose=False), MemoryCacheEvaluator()])
+
+    with FlowOptionsOverride(options={"evaluator": evaluator, "cacheable": True}):
+        assert model.flow.compute(FlowContext(value=10, penalty=1)).value == 101
+        assert model.flow.compute(FlowContext(value=10, penalty=2)).value == 102
+
+    assert calls == {"source": 1, "root": 2}
+
+
+def test_with_inputs_equivalent_child_requests_share_cached_generated_child():
+    calls = {"source": 0}
+
+    @Flow.model
+    def source(value: FromContext[int]) -> int:
+        calls["source"] += 1
+        return value * 10
+
+    @Flow.model
+    def merge(left: int, right: int) -> int:
+        return left + right
+
+    model = merge(
+        left=source().flow.with_inputs(value=lambda ctx: ctx.base + ctx.offset),
+        right=source().flow.with_inputs(value=lambda ctx: ctx.total),
+    )
+
+    with FlowOptionsOverride(options={"evaluator": MemoryCacheEvaluator(), "cacheable": True}):
+        assert model.flow.compute(base=3, offset=4, total=7).value == 140
+
+    assert calls["source"] == 1
+
+
+def test_with_inputs_child_request_change_invalidates_generated_child():
+    calls = {"source": 0}
+
+    @Flow.model
+    def source(value: FromContext[int]) -> int:
+        calls["source"] += 1
+        return value * 10
+
+    @Flow.model
+    def merge(left: int, right: int) -> int:
+        return left + right
+
+    model = merge(
+        left=source().flow.with_inputs(value=lambda ctx: ctx.base + ctx.offset),
+        right=source().flow.with_inputs(value=lambda ctx: ctx.total),
+    )
+
+    with FlowOptionsOverride(options={"evaluator": MemoryCacheEvaluator(), "cacheable": True}):
+        assert model.flow.compute(base=3, offset=4, total=7).value == 140
+        assert model.flow.compute(base=3, offset=5, total=8).value == 160
+
+    assert calls["source"] == 2
+
+
+def test_generated_identity_falls_back_for_non_generated_children():
+    calls = {"child": 0, "root": 0}
+
+    class PlainChild(CallableModel):
+        @property
+        def context_type(self):
+            return FlowContext
+
+        @property
+        def result_type(self):
+            return GenericResult[int]
+
+        @Flow.call
+        def __call__(self, context: FlowContext) -> GenericResult[int]:
+            calls["child"] += 1
+            return GenericResult(value=context.value * 10)
+
+    @Flow.model
+    def root(x: int, penalty: FromContext[int]) -> int:
+        calls["root"] += 1
+        return x + penalty
+
+    model = root(x=PlainChild())
+
+    with FlowOptionsOverride(options={"evaluator": MemoryCacheEvaluator(), "cacheable": True}):
+        assert model.flow.compute(FlowContext(value=10, penalty=1)).value == 101
+        assert model.flow.compute(FlowContext(value=10, penalty=2)).value == 102
+
+    assert calls == {"child": 2, "root": 2}
+
+
+def test_lazy_callable_dependency_participates_in_generated_identity():
+    calls = {"source": 0, "choose": 0}
+
+    @Flow.model
+    def source(value: FromContext[int]) -> int:
+        calls["source"] += 1
+        return value * 10
+
+    @Flow.model
+    def choose(lazy_value: Lazy[int], threshold: FromContext[int]) -> int:
+        calls["choose"] += 1
+        return lazy_value() + threshold
+
+    model = choose(lazy_value=source())
+
+    with FlowOptionsOverride(options={"evaluator": MemoryCacheEvaluator(), "cacheable": True}):
+        assert model.flow.compute(FlowContext(value=3, threshold=1)).value == 31
+        assert model.flow.compute(FlowContext(value=4, threshold=1)).value == 41
+
+    assert calls == {"source": 2, "choose": 2}
+
+
+def test_generated_graph_identity_reuses_child_node_across_unrelated_ambient_changes():
+    @Flow.model
+    def source(value: FromContext[int]) -> int:
+        return value * 10
+
+    @Flow.model
+    def root(x: int, penalty: FromContext[int]) -> int:
+        return x + penalty
+
+    model = root(x=source())
+
+    graph1 = get_dependency_graph(model.__call__.get_evaluation_context(model, FlowContext(value=10, penalty=1)))
+    graph2 = get_dependency_graph(model.__call__.get_evaluation_context(model, FlowContext(value=10, penalty=2)))
+
+    child_key1 = next(key for key in graph1.ids if key != graph1.root_id)
+    child_key2 = next(key for key in graph2.ids if key != graph2.root_id)
+
+    assert child_key1 == child_key2
+    assert graph1.root_id != graph2.root_id
 
 
 def test_auto_wrap_and_serialization_roundtrip():


### PR DESCRIPTION
## Description

In the new functional syntax, @Flow.model decorated functions specify what arguments they pull from the context, but at runtime, a large "bag of context" FlowContext is provided. For correctness of the cache, this PR restricts the context arguments used for caching to be only the ones requested by each model (and it's dependencies).

This helps avoid the issue where an unrelated context parameter inside a `FlowContext` is used to cache a model.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [X] Linting passes (`make lint`)
- [X] Tests pass (`make test`)
- [X] New tests added for new functionality
- [X] Documentation updated (if applicable)
- [X] Changelog / version bump (if applicable)
