### PR TITLE
Add PolarsSelector exttype for polars column selectors

### DIFF
--- a/ccflow/exttypes/polars.py
+++ b/ccflow/exttypes/polars.py
@@ -6,9 +6,10 @@ import numpy as np
 import orjson
 import polars as pl
 from packaging import version
+from polars import selectors as _cs
 from typing_extensions import Self
 
-__all__ = ("PolarsExpression",)
+__all__ = ("PolarsExpression", "PolarsSelector")
 
 
 class _PolarsExprPydanticAnnotation:
@@ -24,8 +25,8 @@ class _PolarsExprPydanticAnnotation:
             serialization=core_schema.plain_serializer_function_ser_schema(cls._encode, return_schema=core_schema.dict_schema()),
         )
 
-    @staticmethod
-    def _decode(obj):
+    @classmethod
+    def _decode(cls, obj):
         # We embed polars expressions as a dict, so we need to convert to a full json string first
         json_str = orjson.dumps(obj).decode("utf-8", "ignore")
         if version.parse(pl.__version__) < version.parse("1.0.0"):
@@ -34,8 +35,8 @@ class _PolarsExprPydanticAnnotation:
             # polars deserializes from a binary format by default.
             return pl.Expr.deserialize(StringIO(json_str), format="json")
 
-    @staticmethod
-    def _encode(obj, info=None):
+    @classmethod
+    def _encode(cls, obj, info=None):
         # obj.meta.serialize produces a string containing a dict, but we just want to return the dict.
         if version.parse(pl.__version__) < version.parse("1.0.0"):
             return orjson.loads(obj.meta.serialize())
@@ -44,29 +45,64 @@ class _PolarsExprPydanticAnnotation:
             return orjson.loads(obj.meta.serialize(format="json"))
 
     @classmethod
+    def _eval_locals(cls) -> dict:
+        local_vars = {"col": pl.col, "c": pl.col, "np": np, "numpy": np, "pl": pl, "polars": pl, "math": math}
+        try:
+            import scipy as sp  # Optional dependency.
+
+            local_vars.update({"scipy": sp, "sp": sp, "sc": sp})
+        except ImportError:
+            pass
+        return local_vars
+
+    @classmethod
+    def _coerce_from_expr(cls, expr: pl.Expr) -> pl.Expr:
+        return expr
+
+    @classmethod
     def _validate(cls, value: Any) -> Self:
         if isinstance(value, pl.Expr):
-            return value
+            return cls._coerce_from_expr(value)
 
         if isinstance(value, str):
             try:
-                local_vars = {"col": pl.col, "c": pl.col, "np": np, "numpy": np, "pl": pl, "polars": pl, "math": math}
-                try:
-                    import scipy as sp  # Optional dependency.
-
-                    local_vars.update({"scipy": sp, "sp": sp, "sc": sp})
-                except ImportError:
-                    pass
-                expression = eval(value, local_vars, {})
+                expression = eval(value, cls._eval_locals(), {})
             except Exception as ex:
                 raise ValueError(f"Error encountered constructing expression - {str(ex)}")
 
-            if not issubclass(type(expression), pl.Expr):
+            if not isinstance(expression, pl.Expr):
                 raise ValueError(f"Supplied value '{value}' does not evaluate to a Polars expression")
-            return expression
+            return cls._coerce_from_expr(expression)
 
         raise ValueError(f"Supplied value '{value}' cannot be converted to a Polars expression")
 
 
-# Public annotated type for Polars expressions
+class _PolarsSelectorPydanticAnnotation(_PolarsExprPydanticAnnotation):
+    """Provides a polars column selector from a string or expression.
+
+    Polars column selectors (``polars.selectors``) subclass ``pl.Expr``, so they serialize via ``Expr.meta.serialize`` like any
+    other expression. However, ``Expr.deserialize`` returns a plain ``Expr`` rather than a ``Selector``, which breaks the selector
+    set-operation overloads (``|``, ``&``, ``-``, ``~``). This annotation promotes the deserialized expression back to a
+    ``Selector`` via ``meta.as_selector()`` and restricts inputs to actual column selectors.
+    """
+
+    @classmethod
+    def _decode(cls, obj):
+        return super()._decode(obj).meta.as_selector()
+
+    @classmethod
+    def _eval_locals(cls) -> dict:
+        return {**super()._eval_locals(), "cs": _cs, "selectors": _cs}
+
+    @classmethod
+    def _coerce_from_expr(cls, expr: pl.Expr) -> pl.Expr:
+        if _cs.is_selector(expr):
+            return expr
+        if expr.meta.is_column_selection():
+            return expr.meta.as_selector()
+        raise ValueError(f"Supplied polars expression {expr!r} is not a column selector")
+
+
 PolarsExpression = Annotated[pl.Expr, _PolarsExprPydanticAnnotation]
+
+PolarsSelector = Annotated[pl.Expr, _PolarsSelectorPydanticAnnotation]

--- a/ccflow/tests/exttypes/test_polars.py
+++ b/ccflow/tests/exttypes/test_polars.py
@@ -2,13 +2,14 @@ import math
 
 import numpy as np
 import polars as pl
+import polars.selectors as cs
 import pytest
 import scipy
 from packaging import version
 from pydantic import TypeAdapter, ValidationError
 
 from ccflow import BaseModel
-from ccflow.exttypes.polars import PolarsExpression
+from ccflow.exttypes.polars import PolarsExpression, PolarsSelector
 
 
 def test_expression_passthrough():
@@ -82,3 +83,80 @@ def test_model_field_and_dataframe_with_columns():
     df = pl.DataFrame({"x": [5, 19, 17, 13, 8, 20], "y": [1, 2, 3, 4, 5, 6]})
     transformed = df.select(m.expr)
     assert transformed.to_series().to_list() == [None, 19, 19, 17, 13, 20]
+
+
+def test_selector_passthrough():
+    adapter = TypeAdapter(PolarsSelector)
+    selector = cs.numeric() - cs.by_name("x")
+    result = adapter.validate_python(selector)
+    assert cs.is_selector(result)
+    assert result.meta.serialize(format="json") == selector.meta.serialize(format="json")
+
+
+def test_selector_from_string():
+    adapter = TypeAdapter(PolarsSelector)
+    expected = cs.numeric() - cs.by_name("x")
+    result = adapter.validate_python("cs.numeric() - cs.by_name('x')")
+    assert cs.is_selector(result)
+    assert result.meta.serialize(format="json") == expected.meta.serialize(format="json")
+
+
+def test_selector_promotes_plain_column_expression():
+    adapter = TypeAdapter(PolarsSelector)
+    result = adapter.validate_python(pl.col("a"))
+    assert cs.is_selector(result)
+
+    result_from_str = adapter.validate_python("pl.col('a')")
+    assert cs.is_selector(result_from_str)
+
+
+def test_selector_rejects_non_selector_expression():
+    adapter = TypeAdapter(PolarsSelector)
+    with pytest.raises(ValidationError):
+        adapter.validate_python(pl.col("a") + 1)
+    with pytest.raises(ValidationError):
+        adapter.validate_python("pl.col('a') + 1")
+
+
+def test_selector_validation_failure():
+    adapter = TypeAdapter(PolarsSelector)
+    with pytest.raises(ValidationError):
+        adapter.validate_python(None)
+    with pytest.raises(ValidationError):
+        adapter.validate_python("pl.DataFrame()")
+    with pytest.raises(ValidationError):
+        adapter.validate_python("invalid_statement")
+
+
+def test_selector_json_roundtrip_preserves_set_op_semantics():
+    adapter = TypeAdapter(PolarsSelector)
+    original = cs.numeric() - cs.by_name("x")
+
+    json_bytes = adapter.dump_json(original)
+    if version.parse(pl.__version__) >= version.parse("1.0.0"):
+        assert json_bytes.decode("utf-8") == original.meta.serialize(format="json")
+
+    restored = adapter.validate_json(json_bytes)
+    assert cs.is_selector(restored)
+
+    # The whole point of this exttype: set-op overloads must still work.
+    combined = restored | cs.string()
+    df = pl.DataFrame({"a": [1], "b": [2.0], "x": [3], "s": ["t"]})
+    assert df.select(restored).columns == df.select(original).columns
+    assert df.select(combined).columns == df.select(original | cs.string()).columns
+
+
+def test_selector_model_field():
+    class DummySelectorModel(BaseModel):
+        sel: PolarsSelector
+
+    m = DummySelectorModel(sel="cs.numeric() - cs.by_name('x')")
+    assert cs.is_selector(m.sel)
+
+    df = pl.DataFrame({"a": [1, 2], "b": [1.0, 2.0], "x": [3, 4], "s": ["p", "q"]})
+    assert df.select(m.sel).columns == ["a", "b"]
+
+    # Round-trip through model_dump_json / model_validate_json.
+    restored = DummySelectorModel.model_validate_json(m.model_dump_json())
+    assert cs.is_selector(restored.sel)
+    assert df.select(restored.sel | cs.string()).columns == ["a", "b", "s"]


### PR DESCRIPTION
Adds `PolarsSelector` in `ccflow/exttypes/polars.py`, a Pydantic annotated type for `polars.selectors` column selectors, parallel to the existing `PolarsExpression`.

## Why

Polars column selectors subclass `pl.Expr` and serialize the same way, but `Expr.deserialize` returns a plain `Expr` rather than a `Selector`. Set-operation overloads (`|`, `&`, `-`, `~`) silently fall through to the `Expr` versions after a config round-trip — e.g. `restored | cs.string()` becomes bitwise-or instead of selector union.

## What's included

- Refactor of `_PolarsExprPydanticAnnotation` to expose `_eval_locals` and `_coerce_from_expr` hooks and make `_decode` / `_encode` classmethods. No behavior change.
- New `_PolarsSelectorPydanticAnnotation` subclass that exposes `cs` / `selectors` in the string-eval scope, promotes plain column-selection `Expr`s via `meta.as_selector()`, rejects non-selector expressions, and reapplies `meta.as_selector()` on deserialized payloads.
- `PolarsSelector = Annotated[pl.Expr, _PolarsSelectorPydanticAnnotation]`.
- Tests for pass-through, string construction, auto-promotion of plain `pl.col`, rejection of non-selectors, JSON round-trip preserving set-op semantics, and `BaseModel` field usage.