### PR TITLE
Handle pickling for generic pydantic models, fixes #210

### DIFF
--- a/ccflow/base.py
+++ b/ccflow/base.py
@@ -7,28 +7,9 @@ import logging
 import pathlib
 import platform
 import sys
-import types
-import typing
 import warnings
-from functools import singledispatch
 from types import GenericAlias, MappingProxyType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Generic,
-    List,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    get_args,
-    get_origin,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union, get_args, get_origin
 
 import pydantic
 from packaging import version
@@ -52,6 +33,7 @@ from typing_extensions import Self
 
 from .exttypes.pyobjectpath import PyObjectPath
 from .local_persistence import register_ccflow_import_path, sync_to_module
+from .pickling import reduce_generic_model_instance
 
 log = logging.getLogger(__name__)
 
@@ -197,155 +179,6 @@ class _SerializeAsAnyMeta(ModelMetaclass):
         namespaces["__annotations__"] = annotations
 
         return super().__new__(self, name, bases, namespaces, **kwargs)
-
-
-class _PydanticGenericTypeSpec(NamedTuple):
-    # Pickle must not rely on process-local names like ``GenericResult[int]``.
-    # Store generic args as data so the receiver can rebuild ``origin[args]``.
-    origin: Type[PydanticBaseModel]
-    args: Tuple[Any, ...]
-
-
-class _GenericAliasTypeSpec(NamedTuple):
-    # Builtin/typing aliases such as ``list[GenericResult[int]]`` are normally
-    # pickleable, but their nested Pydantic generic args may not be. Only wrap
-    # aliases when at least one nested arg had to become portable data.
-    origin: Any
-    args: Tuple[Any, ...]
-    typing_name: Optional[str]
-
-
-def _is_pydantic_generic_specialization(value: Any) -> bool:
-    if not isinstance(value, type):
-        return False
-    metadata = getattr(value, "__pydantic_generic_metadata__", None)
-    return bool(metadata and metadata.get("origin") is not None)
-
-
-@singledispatch
-def _portable_generic_type_arg(value: Any) -> Any:
-    """Convert fragile generic type arguments into pickleable rebuild specs.
-
-    The top-level reducer stores ``origin`` and ``args`` for a model instance,
-    for example ``GenericResult`` and ``(int,)`` for ``GenericResult[int]``.
-    Some args are themselves runtime Pydantic generic classes, such as the
-    ``ListResult[int]`` in ``GenericResult[ListResult[int]]``. Those nested
-    classes have the same cross-process problem as the top-level class: pickle
-    may look for a process-local global named ``ListResult[int]``.
-
-    This helper walks only type arguments, not model field values. Plain
-    importable args like ``int`` are left alone. Pydantic generic
-    specializations become explicit ``(origin, args)`` specs. Generic aliases
-    like ``list[ListResult[int]]`` are wrapped only if one of their nested args
-    needed that conversion. Some type args contain list/tuple containers, such
-    as the argument list in ``typing.Callable[[ListResult[int]], int]``; those
-    containers are also walked because they are part of the type expression.
-    """
-    if _is_pydantic_generic_specialization(value):
-        # Example: ``ListResult[int]`` becomes
-        # ``_PydanticGenericTypeSpec(ListResult, (int,))``. This avoids storing
-        # the generated class object that may not be globally registered in the
-        # receiving process.
-        metadata = value.__pydantic_generic_metadata__
-        return _PydanticGenericTypeSpec(
-            metadata["origin"],
-            tuple(_portable_generic_type_arg(arg) for arg in metadata.get("args", ())),
-        )
-
-    origin = get_origin(value)
-    args = get_args(value)
-    if origin is not None and args:
-        # Example: ``list[ListResult[int]]`` is a normal generic alias, but it
-        # contains a fragile Pydantic specialization. Rebuild the alias from a
-        # portable version of its args only when recursion changed something.
-        portable_args = tuple(_portable_generic_type_arg(arg) for arg in args)
-        if portable_args != args:
-            typing_name = getattr(value, "_name", None) if getattr(value, "__module__", None) == "typing" else None
-            return _GenericAliasTypeSpec(origin, portable_args, typing_name)
-    return value
-
-
-@_portable_generic_type_arg.register(list)
-def _(value: list) -> Any:
-    portable_items = [_portable_generic_type_arg(item) for item in value]
-    return portable_items if portable_items != value else value
-
-
-@_portable_generic_type_arg.register(tuple)
-def _(value: tuple) -> Any:
-    portable_items = tuple(_portable_generic_type_arg(item) for item in value)
-    return portable_items if portable_items != value else value
-
-
-@singledispatch
-def _restore_generic_type_arg(value: Any) -> Any:
-    return value
-
-
-@_restore_generic_type_arg.register(_PydanticGenericTypeSpec)
-def _(value: _PydanticGenericTypeSpec) -> Any:
-    origin, args = value
-    return origin[tuple(_restore_generic_type_arg(arg) for arg in args)]
-
-
-@_restore_generic_type_arg.register(_GenericAliasTypeSpec)
-def _(value: _GenericAliasTypeSpec) -> Any:
-    origin, args, typing_name = value
-    restored_args = tuple(_restore_generic_type_arg(arg) for arg in args)
-    if typing_name is not None:
-        alias = getattr(typing, typing_name)
-        if typing_name == "Optional":
-            non_none_args = tuple(arg for arg in restored_args if arg is not type(None))
-            if len(non_none_args) == 1:
-                return alias[non_none_args[0]]
-        return alias[restored_args]
-    try:
-        return origin[restored_args]
-    except TypeError as exc:
-        if len(restored_args) == 1:
-            try:
-                return origin[restored_args[0]]
-            except TypeError:
-                pass
-        # ``types.UnionType`` is not itself subscriptable; rebuild PEP 604
-        # unions from their members if one of those members needed
-        # portable restoration.
-        union_type = getattr(types, "UnionType", None)
-        if union_type is not None and origin is union_type:
-            result = restored_args[0]
-            for arg in restored_args[1:]:
-                result = result | arg
-            return result
-        raise exc
-
-
-@_restore_generic_type_arg.register(list)
-def _(value: list) -> list:
-    return [_restore_generic_type_arg(item) for item in value]
-
-
-@_restore_generic_type_arg.register(tuple)
-def _(value: tuple) -> tuple:
-    return tuple(_restore_generic_type_arg(item) for item in value)
-
-
-def _new_ccflow_generic_model(origin: Type[PydanticBaseModel], args: Tuple[Any, ...]) -> PydanticBaseModel:
-    """Restore a Pydantic generic specialization without a process-local global.
-
-    Pydantic registers runtime generic specializations like ``GenericResult[int]``
-    in the origin module only in the process that first materializes them. Pickle
-    can then serialize instances by that global name, but fresh workers may not
-    have created the same specialization yet. Restore from the stable origin
-    class plus generic args instead of relying on that process-local module
-    mutation.
-    """
-
-    # Materialize the specialized class in this process. Pickle will restore the
-    # raw Pydantic state afterwards through BaseModel.__setstate__; keeping that
-    # state in the outer pickle stream preserves memo semantics for shared
-    # references, cycles, and protocol-5 buffers.
-    cls = origin[tuple(_restore_generic_type_arg(arg) for arg in args)]
-    return cls.__new__(cls)
 
 
 _BASE_MODEL_METACLASS = ModelMetaclass if _USE_RUNTIME_POLYMORPHIC_SERIALIZATION else _SerializeAsAnyMeta
@@ -522,18 +355,9 @@ class BaseModel(PydanticBaseModel, _RegistryMixin, metaclass=_BASE_MODEL_METACLA
         super().__setstate__(state)
 
     def __reduce_ex__(self, protocol):
-        if _is_pydantic_generic_specialization(type(self)):
-            # Pydantic's default reducer may serialize runtime generic classes
-            # by names like ``GenericResult[int]``. Those names exist only
-            # after a process has materialized that exact specialization, so
-            # Ray/fresh workers can fail to import them while unpickling.
-            # Serialize a stable constructor instead: generic origin plus
-            # portable generic args. Leave Pydantic instance state to the outer
-            # pickle stream so shared references, cycles, and protocol-5 buffers
-            # keep normal pickle semantics.
-            metadata = type(self).__pydantic_generic_metadata__
-            args = tuple(_portable_generic_type_arg(arg) for arg in metadata.get("args", ()))
-            return (_new_ccflow_generic_model, (metadata["origin"], args), self.__getstate__())
+        reducer = reduce_generic_model_instance(self)
+        if reducer is not None:
+            return reducer
         return super().__reduce_ex__(protocol)
 
 

--- a/ccflow/base.py
+++ b/ccflow/base.py
@@ -7,9 +7,28 @@ import logging
 import pathlib
 import platform
 import sys
+import types
+import typing
 import warnings
+from functools import singledispatch
 from types import GenericAlias, MappingProxyType
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union, get_args, get_origin
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Generic,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from packaging import version
 
@@ -163,6 +182,155 @@ class _SerializeAsAnyMeta(ModelMetaclass):
         namespaces["__annotations__"] = annotations
 
         return super().__new__(self, name, bases, namespaces, **kwargs)
+
+
+class _PydanticGenericTypeSpec(NamedTuple):
+    # Pickle must not rely on process-local names like ``GenericResult[int]``.
+    # Store generic args as data so the receiver can rebuild ``origin[args]``.
+    origin: Type[PydanticBaseModel]
+    args: Tuple[Any, ...]
+
+
+class _GenericAliasTypeSpec(NamedTuple):
+    # Builtin/typing aliases such as ``list[GenericResult[int]]`` are normally
+    # pickleable, but their nested Pydantic generic args may not be. Only wrap
+    # aliases when at least one nested arg had to become portable data.
+    origin: Any
+    args: Tuple[Any, ...]
+    typing_name: Optional[str]
+
+
+def _is_pydantic_generic_specialization(value: Any) -> bool:
+    if not isinstance(value, type):
+        return False
+    metadata = getattr(value, "__pydantic_generic_metadata__", None)
+    return bool(metadata and metadata.get("origin") is not None)
+
+
+@singledispatch
+def _portable_generic_type_arg(value: Any) -> Any:
+    """Convert fragile generic type arguments into pickleable rebuild specs.
+
+    The top-level reducer stores ``origin`` and ``args`` for a model instance,
+    for example ``GenericResult`` and ``(int,)`` for ``GenericResult[int]``.
+    Some args are themselves runtime Pydantic generic classes, such as the
+    ``ListResult[int]`` in ``GenericResult[ListResult[int]]``. Those nested
+    classes have the same cross-process problem as the top-level class: pickle
+    may look for a process-local global named ``ListResult[int]``.
+
+    This helper walks only type arguments, not model field values. Plain
+    importable args like ``int`` are left alone. Pydantic generic
+    specializations become explicit ``(origin, args)`` specs. Generic aliases
+    like ``list[ListResult[int]]`` are wrapped only if one of their nested args
+    needed that conversion. Some type args contain list/tuple containers, such
+    as the argument list in ``typing.Callable[[ListResult[int]], int]``; those
+    containers are also walked because they are part of the type expression.
+    """
+    if _is_pydantic_generic_specialization(value):
+        # Example: ``ListResult[int]`` becomes
+        # ``_PydanticGenericTypeSpec(ListResult, (int,))``. This avoids storing
+        # the generated class object that may not be globally registered in the
+        # receiving process.
+        metadata = value.__pydantic_generic_metadata__
+        return _PydanticGenericTypeSpec(
+            metadata["origin"],
+            tuple(_portable_generic_type_arg(arg) for arg in metadata.get("args", ())),
+        )
+
+    origin = get_origin(value)
+    args = get_args(value)
+    if origin is not None and args:
+        # Example: ``list[ListResult[int]]`` is a normal generic alias, but it
+        # contains a fragile Pydantic specialization. Rebuild the alias from a
+        # portable version of its args only when recursion changed something.
+        portable_args = tuple(_portable_generic_type_arg(arg) for arg in args)
+        if portable_args != args:
+            typing_name = getattr(value, "_name", None) if getattr(value, "__module__", None) == "typing" else None
+            return _GenericAliasTypeSpec(origin, portable_args, typing_name)
+    return value
+
+
+@_portable_generic_type_arg.register(list)
+def _(value: list) -> Any:
+    portable_items = [_portable_generic_type_arg(item) for item in value]
+    return portable_items if portable_items != value else value
+
+
+@_portable_generic_type_arg.register(tuple)
+def _(value: tuple) -> Any:
+    portable_items = tuple(_portable_generic_type_arg(item) for item in value)
+    return portable_items if portable_items != value else value
+
+
+@singledispatch
+def _restore_generic_type_arg(value: Any) -> Any:
+    return value
+
+
+@_restore_generic_type_arg.register(_PydanticGenericTypeSpec)
+def _(value: _PydanticGenericTypeSpec) -> Any:
+    origin, args = value
+    return origin[tuple(_restore_generic_type_arg(arg) for arg in args)]
+
+
+@_restore_generic_type_arg.register(_GenericAliasTypeSpec)
+def _(value: _GenericAliasTypeSpec) -> Any:
+    origin, args, typing_name = value
+    restored_args = tuple(_restore_generic_type_arg(arg) for arg in args)
+    if typing_name is not None:
+        alias = getattr(typing, typing_name)
+        if typing_name == "Optional":
+            non_none_args = tuple(arg for arg in restored_args if arg is not type(None))
+            if len(non_none_args) == 1:
+                return alias[non_none_args[0]]
+        return alias[restored_args]
+    try:
+        return origin[restored_args]
+    except TypeError as exc:
+        if len(restored_args) == 1:
+            try:
+                return origin[restored_args[0]]
+            except TypeError:
+                pass
+        # ``types.UnionType`` is not itself subscriptable; rebuild PEP 604
+        # unions from their members if one of those members needed
+        # portable restoration.
+        union_type = getattr(types, "UnionType", None)
+        if union_type is not None and origin is union_type:
+            result = restored_args[0]
+            for arg in restored_args[1:]:
+                result = result | arg
+            return result
+        raise exc
+
+
+@_restore_generic_type_arg.register(list)
+def _(value: list) -> list:
+    return [_restore_generic_type_arg(item) for item in value]
+
+
+@_restore_generic_type_arg.register(tuple)
+def _(value: tuple) -> tuple:
+    return tuple(_restore_generic_type_arg(item) for item in value)
+
+
+def _new_ccflow_generic_model(origin: Type[PydanticBaseModel], args: Tuple[Any, ...]) -> PydanticBaseModel:
+    """Restore a Pydantic generic specialization without a process-local global.
+
+    Pydantic registers runtime generic specializations like ``GenericResult[int]``
+    in the origin module only in the process that first materializes them. Pickle
+    can then serialize instances by that global name, but fresh workers may not
+    have created the same specialization yet. Restore from the stable origin
+    class plus generic args instead of relying on that process-local module
+    mutation.
+    """
+
+    # Materialize the specialized class in this process. Pickle will restore the
+    # raw Pydantic state afterwards through BaseModel.__setstate__; keeping that
+    # state in the outer pickle stream preserves memo semantics for shared
+    # references, cycles, and protocol-5 buffers.
+    cls = origin[tuple(_restore_generic_type_arg(arg) for arg in args)]
+    return cls.__new__(cls)
 
 
 class BaseModel(PydanticBaseModel, _RegistryMixin, metaclass=_SerializeAsAnyMeta):
@@ -333,6 +501,21 @@ class BaseModel(PydanticBaseModel, _RegistryMixin, metaclass=_SerializeAsAnyMeta
     def __setstate__(self, state):
         state["__pydantic_fields_set__"] = set(state["__pydantic_fields_set__"])
         super().__setstate__(state)
+
+    def __reduce_ex__(self, protocol):
+        if _is_pydantic_generic_specialization(type(self)):
+            # Pydantic's default reducer may serialize runtime generic classes
+            # by names like ``GenericResult[int]``. Those names exist only
+            # after a process has materialized that exact specialization, so
+            # Ray/fresh workers can fail to import them while unpickling.
+            # Serialize a stable constructor instead: generic origin plus
+            # portable generic args. Leave Pydantic instance state to the outer
+            # pickle stream so shared references, cycles, and protocol-5 buffers
+            # keep normal pickle semantics.
+            metadata = type(self).__pydantic_generic_metadata__
+            args = tuple(_portable_generic_type_arg(arg) for arg in metadata.get("args", ()))
+            return (_new_ccflow_generic_model, (metadata["origin"], args), self.__getstate__())
+        return super().__reduce_ex__(protocol)
 
 
 class _ModelRegistryData(PydanticBaseModel):

--- a/ccflow/pickling.py
+++ b/ccflow/pickling.py
@@ -1,0 +1,140 @@
+"""Pickle helpers for ccflow model classes.
+
+This module works around Pydantic generic specializations sometimes pickling by
+process-local generated class names, such as ``GenericResult[int]``. Fresh
+processes may not have materialized those names yet, so unpickling can fail
+before ccflow code gets control. See the upstream Pydantic issue for the
+underlying behavior:
+
+https://github.com/pydantic/pydantic/issues/9390
+
+If Pydantic or cloudpickle eventually make generated generic model
+specializations portable across fresh processes without relying on module-global
+side effects, this module can likely be deleted and ``BaseModel.__reduce_ex__``
+can fall back to Pydantic's default reducer.
+"""
+
+import types
+from functools import singledispatch
+from typing import Any, NamedTuple, Optional, Tuple, Type, get_args, get_origin
+
+from pydantic import BaseModel as PydanticBaseModel
+
+__all__ = ("reduce_generic_model_instance",)
+
+
+class _GenericTypeSpec(NamedTuple):
+    # Pickle must not rely on process-local names like ``GenericResult[int]``.
+    # Store generic args as data so the receiver can rebuild ``origin[args]``.
+    origin: Any
+    args: Tuple[Any, ...]
+
+
+def _is_pydantic_generic_specialization(value: Any) -> bool:
+    if not isinstance(value, type):
+        return False
+    metadata = getattr(value, "__pydantic_generic_metadata__", None)
+    return bool(metadata and metadata.get("origin") is not None)
+
+
+@singledispatch
+def _portable_generic_type_arg_with_changed(value: Any) -> tuple[Any, bool]:
+    if _is_pydantic_generic_specialization(value):
+        metadata = value.__pydantic_generic_metadata__
+        portable_args, _ = _portable_generic_type_args(metadata["args"])
+        return _GenericTypeSpec(metadata["origin"], portable_args), True
+
+    origin = get_origin(value)
+    args = get_args(value)
+    if origin is not None and args:
+        portable_args, changed = _portable_generic_type_args(args)
+        if changed:
+            return _GenericTypeSpec(origin, portable_args), True
+    return value, False
+
+
+@_portable_generic_type_arg_with_changed.register(list)
+def _(value: list) -> tuple[Any, bool]:
+    portable_items = []
+    changed = False
+    for item in value:
+        portable_item, item_changed = _portable_generic_type_arg_with_changed(item)
+        portable_items.append(portable_item)
+        changed = changed or item_changed
+    return (portable_items, True) if changed else (value, False)
+
+
+@_portable_generic_type_arg_with_changed.register(tuple)
+def _(value: tuple) -> tuple[Any, bool]:
+    portable_items, changed = _portable_generic_type_args(value)
+    return (portable_items, True) if changed else (value, False)
+
+
+def _portable_generic_type_args(args: tuple[Any, ...]) -> tuple[tuple[Any, ...], bool]:
+    portable_args = []
+    changed = False
+    for arg in args:
+        portable_arg, arg_changed = _portable_generic_type_arg_with_changed(arg)
+        portable_args.append(portable_arg)
+        changed = changed or arg_changed
+    return tuple(portable_args), changed
+
+
+def _portable_generic_type_arg(value: Any) -> Any:
+    return _portable_generic_type_arg_with_changed(value)[0]
+
+
+@singledispatch
+def _restore_generic_type_arg(value: Any) -> Any:
+    return value
+
+
+@_restore_generic_type_arg.register(_GenericTypeSpec)
+def _(value: _GenericTypeSpec) -> Any:
+    origin, args = value
+    restored_args = tuple(_restore_generic_type_arg(arg) for arg in args)
+    try:
+        return origin[restored_args]
+    except TypeError as exc:
+        if len(restored_args) == 1:
+            try:
+                return origin[restored_args[0]]
+            except TypeError:
+                pass
+        # ``types.UnionType`` is not itself subscriptable; rebuild PEP 604
+        # unions from their members if one of those members needed restoration.
+        union_type = getattr(types, "UnionType", None)
+        if union_type is not None and origin is union_type:
+            result = restored_args[0]
+            for arg in restored_args[1:]:
+                result = result | arg
+            return result
+        raise exc
+
+
+@_restore_generic_type_arg.register(list)
+def _(value: list) -> list:
+    return [_restore_generic_type_arg(item) for item in value]
+
+
+@_restore_generic_type_arg.register(tuple)
+def _(value: tuple) -> tuple:
+    return tuple(_restore_generic_type_arg(item) for item in value)
+
+
+def _new_ccflow_generic_model(origin: Type[PydanticBaseModel], args: Tuple[Any, ...]) -> PydanticBaseModel:
+    """Restore a Pydantic generic specialization without a process-local global."""
+
+    cls = origin[tuple(_restore_generic_type_arg(arg) for arg in args)]
+    return cls.__new__(cls)
+
+
+def reduce_generic_model_instance(model: PydanticBaseModel) -> Optional[tuple[Any, tuple[Any, ...], dict[str, Any]]]:
+    """Return a portable reducer for Pydantic generic specializations."""
+
+    if not _is_pydantic_generic_specialization(type(model)):
+        return None
+
+    metadata = type(model).__pydantic_generic_metadata__
+    args, _ = _portable_generic_type_args(metadata["args"])
+    return (_new_ccflow_generic_model, (metadata["origin"], args), model.__getstate__())

--- a/ccflow/tests/test_base_cloudpickle.py
+++ b/ccflow/tests/test_base_cloudpickle.py
@@ -1,0 +1,321 @@
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _run_python(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=30)
+
+
+def _create_payloads_in_fresh_process(creator_body: str) -> dict[str, dict[str, str]]:
+    # The bug only appears when the receiver has not already materialized the
+    # same Pydantic generic specialization. Create payloads in a subprocess so
+    # the pytest process cannot accidentally warm the receiver's generic cache.
+    creator = _run_python(
+        "import base64\n"
+        "import cloudpickle\n"
+        "import json\n"
+        "import pickle\n"
+        f"{textwrap.dedent(creator_body)}\n"
+        "encoded = {}\n"
+        "for name, (serializer, value) in payloads.items():\n"
+        "    module = pickle if serializer == 'pickle' else cloudpickle\n"
+        "    encoded[name] = {\n"
+        "        'serializer': serializer,\n"
+        "        'payload': base64.b64encode(module.dumps(value, protocol=5)).decode(),\n"
+        "    }\n"
+        "print(json.dumps(encoded, sort_keys=True))\n"
+    )
+    assert creator.returncode == 0, creator.stderr
+    return json.loads(creator.stdout)
+
+
+def _assert_payloads_load_in_fresh_process(creator_body: str, assertions: str, *, extra_loader_setup: str = "") -> None:
+    encoded_payloads = _create_payloads_in_fresh_process(creator_body)
+    # First load each payload in its own fresh process. The original bug was
+    # sensitive to whether a worker had already materialized the same generic
+    # specialization, so a shared loader process can accidentally warm the
+    # receiver and create false positives.
+    for name, spec in encoded_payloads.items():
+        cold_loader = _run_python(
+            "import base64\n"
+            "import cloudpickle\n"
+            "import json\n"
+            "import pickle\n"
+            f"{textwrap.dedent(extra_loader_setup)}\n"
+            f"spec = json.loads({json.dumps(spec)!r})\n"
+            "module = pickle if spec['serializer'] == 'pickle' else cloudpickle\n"
+            "module.loads(base64.b64decode(spec['payload']))\n"
+        )
+        assert cold_loader.returncode == 0, f"{name}: {cold_loader.stderr}"
+
+    # Load in a second fresh process, then run all assertions there. Keeping many
+    # payloads in one process pair keeps the detailed assertions cheap. The
+    # per-payload loop above already verifies cold-receiver loading.
+    loader = _run_python(
+        "import base64\n"
+        "import cloudpickle\n"
+        "import json\n"
+        "import pickle\n"
+        f"{textwrap.dedent(extra_loader_setup)}\n"
+        f"encoded = json.loads({json.dumps(encoded_payloads)!r})\n"
+        "values = {}\n"
+        "for name, spec in encoded.items():\n"
+        "    module = pickle if spec['serializer'] == 'pickle' else cloudpickle\n"
+        "    values[name] = module.loads(base64.b64decode(spec['payload']))\n"
+        f"{textwrap.dedent(assertions)}\n"
+    )
+    assert loader.returncode == 0, loader.stderr
+
+
+def test_ccflow_generic_specializations_pickle_across_fresh_processes():
+    # One matrix test covers the ccflow-provided generic families and the hard
+    # type-argument shapes: nested Pydantic generics, builtin aliases containing
+    # Pydantic generics, and PEP 604 unions containing Pydantic generics.
+    _assert_payloads_load_in_fresh_process(
+        """
+        import numpy as np
+        from typing import Callable, ClassVar, Final, List, Optional
+
+        from ccflow import GenericContext, GenericResult
+        from ccflow.result import DictResult, ListResult
+        from ccflow.result.numpy import NumpyResult
+
+        payloads = {
+            "standard_pickle_result": ("pickle", GenericResult[int](value=5)),
+            "generic_result": ("cloudpickle", GenericResult[int](value=6)),
+            "generic_context": ("cloudpickle", GenericContext[str](value="abc")),
+            "list_result": ("cloudpickle", ListResult[int](value=[1, 2])),
+            "dict_result": ("cloudpickle", DictResult[str, float](value={"a": 1.5})),
+            "numpy_result": (
+                "cloudpickle",
+                NumpyResult[np.float64](array=np.array([1.0, 2.0], dtype=np.float64)),
+            ),
+            "nested_result": (
+                "cloudpickle",
+                GenericResult[ListResult[int]](value=ListResult[int](value=[1, 2])),
+            ),
+            "list_alias_result": (
+                "cloudpickle",
+                GenericResult[list[ListResult[int]]](value=[ListResult[int](value=[1])]),
+            ),
+            "typing_list_alias_result": (
+                "cloudpickle",
+                GenericResult[List[ListResult[int]]](value=[ListResult[int](value=[2])]),
+            ),
+            "callable_alias_result": (
+                "cloudpickle",
+                GenericResult[Callable[[ListResult[int]], int]](value=lambda result: len(result.value)),
+            ),
+            "optional_alias_result": (
+                "cloudpickle",
+                GenericResult[Optional[ListResult[int]]](value=ListResult[int](value=[4])),
+            ),
+            "classvar_alias_result": (
+                "cloudpickle",
+                GenericResult[ClassVar[ListResult[int]]](value=ListResult[int](value=[5])),
+            ),
+            "final_alias_result": (
+                "cloudpickle",
+                GenericResult[Final[ListResult[int]]](value=ListResult[int](value=[6])),
+            ),
+            "dict_alias_result": (
+                "cloudpickle",
+                GenericResult[dict[str, GenericContext[int]]](value={"a": GenericContext[int](value=1)}),
+            ),
+            "union_result": (
+                "cloudpickle",
+                GenericResult[GenericContext[int] | None](value=GenericContext[int](value=1)),
+            ),
+        }
+        """,
+        """
+        import numpy as np
+        from typing import Callable, ClassVar, Final, List, Optional
+
+        from ccflow import GenericContext, GenericResult
+        from ccflow.result import DictResult, ListResult
+        from ccflow.result.numpy import NumpyResult
+
+        assert values["standard_pickle_result"] == GenericResult[int](value=5)
+        assert type(values["standard_pickle_result"]).__pydantic_generic_metadata__["args"] == (int,)
+
+        assert values["generic_result"] == GenericResult[int](value=6)
+        assert values["generic_context"] == GenericContext[str](value="abc")
+        assert values["list_result"] == ListResult[int](value=[1, 2])
+        assert values["dict_result"] == DictResult[str, float](value={"a": 1.5})
+
+        assert type(values["numpy_result"]) is NumpyResult[np.float64]
+        np.testing.assert_array_equal(values["numpy_result"].array, np.array([1.0, 2.0], dtype=np.float64))
+
+        assert values["nested_result"] == GenericResult[ListResult[int]](value=ListResult[int](value=[1, 2]))
+        assert type(values["nested_result"]).__pydantic_generic_metadata__["args"] == (ListResult[int],)
+        assert type(values["nested_result"].value).__pydantic_generic_metadata__["args"] == (int,)
+
+        assert values["list_alias_result"] == GenericResult[list[ListResult[int]]](value=[ListResult[int](value=[1])])
+        assert type(values["list_alias_result"]).__pydantic_generic_metadata__["args"] == (list[ListResult[int]],)
+        assert type(values["list_alias_result"].value[0]).__pydantic_generic_metadata__["args"] == (int,)
+
+        assert values["typing_list_alias_result"] == GenericResult[List[ListResult[int]]](
+            value=[ListResult[int](value=[2])]
+        )
+        assert type(values["typing_list_alias_result"]).__pydantic_generic_metadata__["args"] == (List[ListResult[int]],)
+
+        assert values["callable_alias_result"].value(ListResult[int](value=[1, 2, 3])) == 3
+        assert type(values["callable_alias_result"]).__pydantic_generic_metadata__["args"] == (
+            Callable[[ListResult[int]], int],
+        )
+
+        assert values["optional_alias_result"] == GenericResult[Optional[ListResult[int]]](
+            value=ListResult[int](value=[4])
+        )
+        assert type(values["optional_alias_result"]).__pydantic_generic_metadata__["args"] == (
+            Optional[ListResult[int]],
+        )
+
+        assert values["classvar_alias_result"] == GenericResult[ClassVar[ListResult[int]]](
+            value=ListResult[int](value=[5])
+        )
+        assert type(values["classvar_alias_result"]).__pydantic_generic_metadata__["args"] == (
+            ClassVar[ListResult[int]],
+        )
+
+        assert values["final_alias_result"] == GenericResult[Final[ListResult[int]]](
+            value=ListResult[int](value=[6])
+        )
+        assert type(values["final_alias_result"]).__pydantic_generic_metadata__["args"] == (
+            Final[ListResult[int]],
+        )
+
+        assert values["dict_alias_result"] == GenericResult[dict[str, GenericContext[int]]](
+            value={"a": GenericContext[int](value=1)}
+        )
+        assert type(values["dict_alias_result"]).__pydantic_generic_metadata__["args"] == (
+            dict[str, GenericContext[int]],
+        )
+        assert type(values["dict_alias_result"].value["a"]).__pydantic_generic_metadata__["args"] == (int,)
+
+        assert values["union_result"] == GenericResult[GenericContext[int] | None](value=GenericContext[int](value=1))
+        assert type(values["union_result"].value).__pydantic_generic_metadata__["args"] == (int,)
+        """,
+    )
+
+
+def test_user_generic_and_non_generic_ccflow_models_pickle_across_fresh_processes(tmp_path: Path):
+    # User subclasses exercise the same BaseModel reducer without depending on
+    # ccflow's result/context classes. The non-generic case proves the generic
+    # override has not captured ordinary BaseModel pickling.
+    module_path = tmp_path / "generic_user_model.py"
+    module_path.write_text(
+        textwrap.dedent(
+            """
+            from typing import Generic, TypeVar
+
+            from pydantic import PrivateAttr
+
+            from ccflow import BaseModel
+
+            T = TypeVar("T")
+
+            class UserBox(BaseModel, Generic[T]):
+                value: T
+                _bonus: int = PrivateAttr(default=1)
+            """
+        )
+    )
+
+    _assert_payloads_load_in_fresh_process(
+        f"""
+        import sys
+        from typing import Generic, TypeVar
+
+        from pydantic import PrivateAttr
+
+        from ccflow import BaseModel
+
+        sys.path.insert(0, {str(tmp_path)!r})
+        from generic_user_model import UserBox
+
+        T = TypeVar("T")
+
+        class LocalBox(BaseModel, Generic[T]):
+            value: T
+            _bonus: int = PrivateAttr(default=1)
+
+        class LocalPayload(BaseModel):
+            value: int
+            _bonus: int = PrivateAttr(default=1)
+
+        importable = UserBox[int](value=2)
+        importable._bonus = 40
+        local_generic = LocalBox[int](value=3)
+        local_generic._bonus = 41
+        local_payload = LocalPayload(value=4)
+        local_payload._bonus = 42
+
+        payloads = {{
+            "importable_generic": ("cloudpickle", importable),
+            "local_generic": ("cloudpickle", local_generic),
+            "local_payload": ("cloudpickle", local_payload),
+        }}
+        """,
+        """
+        from generic_user_model import UserBox
+
+        assert type(values["importable_generic"]) is UserBox[int]
+        assert values["importable_generic"].value == 2
+        assert values["importable_generic"]._bonus == 40
+
+        assert values["local_generic"].value == 3
+        assert values["local_generic"]._bonus == 41
+        assert type(values["local_generic"]).__name__ == "LocalBox[int]"
+        assert type(values["local_generic"]).__pydantic_generic_metadata__["args"] == (int,)
+
+        assert values["local_payload"].value == 4
+        assert values["local_payload"]._bonus == 42
+        assert type(values["local_payload"]).__name__ == "LocalPayload"
+        """,
+        extra_loader_setup=f"""
+        import sys
+        sys.path.insert(0, {str(tmp_path)!r})
+        """,
+    )
+
+
+def test_ccflow_generic_result_cloudpickle_in_ray_worker_without_receiver_materialization():
+    import ray
+
+    # Ray is the production-shaped failure mode: workers are fresh processes and
+    # may deserialize before ``GenericResult[int]`` has ever been created there.
+    payload = _create_payloads_in_fresh_process(
+        """
+        from ccflow import GenericResult
+
+        payloads = {"generic_result": ("cloudpickle", GenericResult[int](value=5))}
+        """
+    )["generic_result"]["payload"]
+
+    @ray.remote
+    def load_payload(encoded_payload: str):
+        import base64
+
+        import cloudpickle
+
+        import ccflow.result.generic as generic_module
+        from ccflow import GenericResult  # noqa: F401
+
+        # Importing the generic origin must not be enough to make the test pass.
+        # The worker should not know about ``GenericResult[int]`` until the
+        # reducer intentionally rebuilds it during cloudpickle.loads.
+        had_specialization_before_load = hasattr(generic_module, "GenericResult[int]")
+        value = cloudpickle.loads(base64.b64decode(encoded_payload))
+        return (
+            had_specialization_before_load,
+            value.value,
+            tuple(arg.__name__ for arg in type(value).__pydantic_generic_metadata__["args"]),
+        )
+
+    with ray.init(num_cpus=1):
+        assert ray.get(load_payload.remote(payload), timeout=30) == (False, 5, ("int",))

--- a/ccflow/tests/test_base_cloudpickle.py
+++ b/ccflow/tests/test_base_cloudpickle.py
@@ -1,89 +1,80 @@
-import json
-import subprocess
-import sys
+import base64
+import multiprocessing
+import pickle
 import textwrap
+import traceback
 from pathlib import Path
+from queue import Empty
+
+import cloudpickle
 
 
-def _run_python(script: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=30)
+def _spawn_entrypoint(result_queue, worker, args):
+    try:
+        result_queue.put(("ok", worker(*args)))
+    except BaseException:
+        result_queue.put(("error", traceback.format_exc()))
 
 
-def _create_payloads_in_fresh_process(creator_body: str) -> dict[str, dict[str, str]]:
-    # The bug only appears when the receiver has not already materialized the
-    # same Pydantic generic specialization. Create payloads in a subprocess so
-    # the pytest process cannot accidentally warm the receiver's generic cache.
-    creator = _run_python(
-        "import base64\n"
-        "import cloudpickle\n"
-        "import json\n"
-        "import pickle\n"
-        f"{textwrap.dedent(creator_body)}\n"
-        "encoded = {}\n"
-        "for name, (serializer, value) in payloads.items():\n"
-        "    module = pickle if serializer == 'pickle' else cloudpickle\n"
-        "    encoded[name] = {\n"
-        "        'serializer': serializer,\n"
-        "        'payload': base64.b64encode(module.dumps(value, protocol=5)).decode(),\n"
-        "    }\n"
-        "print(json.dumps(encoded, sort_keys=True))\n"
-    )
-    assert creator.returncode == 0, creator.stderr
-    return json.loads(creator.stdout)
+def _run_in_spawned_process(worker, *args, timeout: int = 30):
+    ctx = multiprocessing.get_context("spawn")
+    result_queue = ctx.Queue()
+    process = ctx.Process(target=_spawn_entrypoint, args=(result_queue, worker, args))
+    process.start()
+    try:
+        status, result = result_queue.get(timeout=timeout)
+    except Empty:
+        process.terminate()
+        process.join(timeout=5)
+        raise AssertionError(f"{worker.__name__} timed out after {timeout} seconds") from None
+
+    process.join(timeout=timeout)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=5)
+        raise AssertionError(f"{worker.__name__} did not exit after returning a result")
+    if process.exitcode != 0:
+        raise AssertionError(f"{worker.__name__} exited with {process.exitcode}")
+    if status == "error":
+        raise AssertionError(result)
+    return result
 
 
-def _assert_payloads_load_in_fresh_process(creator_body: str, assertions: str, *, extra_loader_setup: str = "") -> None:
-    encoded_payloads = _create_payloads_in_fresh_process(creator_body)
-    # First load each payload in its own fresh process. The original bug was
-    # sensitive to whether a worker had already materialized the same generic
-    # specialization, so a shared loader process can accidentally warm the
-    # receiver and create false positives.
-    for name, spec in encoded_payloads.items():
-        cold_loader = _run_python(
-            "import base64\n"
-            "import cloudpickle\n"
-            "import json\n"
-            "import pickle\n"
-            f"{textwrap.dedent(extra_loader_setup)}\n"
-            f"spec = json.loads({json.dumps(spec)!r})\n"
-            "module = pickle if spec['serializer'] == 'pickle' else cloudpickle\n"
-            "module.loads(base64.b64decode(spec['payload']))\n"
-        )
-        assert cold_loader.returncode == 0, f"{name}: {cold_loader.stderr}"
-
-    # Load in a second fresh process, then run all assertions there. Keeping many
-    # payloads in one process pair keeps the detailed assertions cheap. The
-    # per-payload loop above already verifies cold-receiver loading.
-    loader = _run_python(
-        "import base64\n"
-        "import cloudpickle\n"
-        "import json\n"
-        "import pickle\n"
-        f"{textwrap.dedent(extra_loader_setup)}\n"
-        f"encoded = json.loads({json.dumps(encoded_payloads)!r})\n"
-        "values = {}\n"
-        "for name, spec in encoded.items():\n"
-        "    module = pickle if spec['serializer'] == 'pickle' else cloudpickle\n"
-        "    values[name] = module.loads(base64.b64decode(spec['payload']))\n"
-        f"{textwrap.dedent(assertions)}\n"
-    )
-    assert loader.returncode == 0, loader.stderr
+def _serialize_payloads(payloads: dict[str, tuple[str, object]]) -> dict[str, dict[str, str]]:
+    encoded = {}
+    for name, (serializer, value) in payloads.items():
+        module = pickle if serializer == "pickle" else cloudpickle
+        encoded[name] = {
+            "serializer": serializer,
+            "payload": base64.b64encode(module.dumps(value, protocol=5)).decode(),
+        }
+    return encoded
 
 
-def test_ccflow_generic_specializations_pickle_across_fresh_processes():
-    # One matrix test covers the ccflow-provided generic families and the hard
-    # type-argument shapes: nested Pydantic generics, builtin aliases containing
-    # Pydantic generics, and PEP 604 unions containing Pydantic generics.
-    _assert_payloads_load_in_fresh_process(
-        """
-        import numpy as np
-        from typing import Callable, ClassVar, Final, List, Optional
+def _load_payload(spec: dict[str, str]):
+    module = pickle if spec["serializer"] == "pickle" else cloudpickle
+    return module.loads(base64.b64decode(spec["payload"]))
 
-        from ccflow import GenericContext, GenericResult
-        from ccflow.result import DictResult, ListResult
-        from ccflow.result.numpy import NumpyResult
 
-        payloads = {
+def _load_payloads(encoded_payloads: dict[str, dict[str, str]]) -> dict[str, object]:
+    return {name: _load_payload(spec) for name, spec in encoded_payloads.items()}
+
+
+def _load_payload_without_return(spec: dict[str, str]) -> None:
+    _load_payload(spec)
+
+
+def _create_ccflow_generic_payloads() -> dict[str, dict[str, str]]:
+    from typing import Callable, ClassVar, Final, List, Optional
+
+    import numpy as np
+
+    from ccflow import GenericContext, GenericResult
+    from ccflow.result import DictResult, ListResult
+    from ccflow.result.numpy import NumpyResult
+
+    return _serialize_payloads(
+        {
             "standard_pickle_result": ("pickle", GenericResult[int](value=5)),
             "generic_result": ("cloudpickle", GenericResult[int](value=6)),
             "generic_context": ("cloudpickle", GenericContext[str](value="abc")),
@@ -130,77 +121,178 @@ def test_ccflow_generic_specializations_pickle_across_fresh_processes():
                 GenericResult[GenericContext[int] | None](value=GenericContext[int](value=1)),
             ),
         }
-        """,
-        """
-        import numpy as np
-        from typing import Callable, ClassVar, Final, List, Optional
-
-        from ccflow import GenericContext, GenericResult
-        from ccflow.result import DictResult, ListResult
-        from ccflow.result.numpy import NumpyResult
-
-        assert values["standard_pickle_result"] == GenericResult[int](value=5)
-        assert type(values["standard_pickle_result"]).__pydantic_generic_metadata__["args"] == (int,)
-
-        assert values["generic_result"] == GenericResult[int](value=6)
-        assert values["generic_context"] == GenericContext[str](value="abc")
-        assert values["list_result"] == ListResult[int](value=[1, 2])
-        assert values["dict_result"] == DictResult[str, float](value={"a": 1.5})
-
-        assert type(values["numpy_result"]) is NumpyResult[np.float64]
-        np.testing.assert_array_equal(values["numpy_result"].array, np.array([1.0, 2.0], dtype=np.float64))
-
-        assert values["nested_result"] == GenericResult[ListResult[int]](value=ListResult[int](value=[1, 2]))
-        assert type(values["nested_result"]).__pydantic_generic_metadata__["args"] == (ListResult[int],)
-        assert type(values["nested_result"].value).__pydantic_generic_metadata__["args"] == (int,)
-
-        assert values["list_alias_result"] == GenericResult[list[ListResult[int]]](value=[ListResult[int](value=[1])])
-        assert type(values["list_alias_result"]).__pydantic_generic_metadata__["args"] == (list[ListResult[int]],)
-        assert type(values["list_alias_result"].value[0]).__pydantic_generic_metadata__["args"] == (int,)
-
-        assert values["typing_list_alias_result"] == GenericResult[List[ListResult[int]]](
-            value=[ListResult[int](value=[2])]
-        )
-        assert type(values["typing_list_alias_result"]).__pydantic_generic_metadata__["args"] == (List[ListResult[int]],)
-
-        assert values["callable_alias_result"].value(ListResult[int](value=[1, 2, 3])) == 3
-        assert type(values["callable_alias_result"]).__pydantic_generic_metadata__["args"] == (
-            Callable[[ListResult[int]], int],
-        )
-
-        assert values["optional_alias_result"] == GenericResult[Optional[ListResult[int]]](
-            value=ListResult[int](value=[4])
-        )
-        assert type(values["optional_alias_result"]).__pydantic_generic_metadata__["args"] == (
-            Optional[ListResult[int]],
-        )
-
-        assert values["classvar_alias_result"] == GenericResult[ClassVar[ListResult[int]]](
-            value=ListResult[int](value=[5])
-        )
-        assert type(values["classvar_alias_result"]).__pydantic_generic_metadata__["args"] == (
-            ClassVar[ListResult[int]],
-        )
-
-        assert values["final_alias_result"] == GenericResult[Final[ListResult[int]]](
-            value=ListResult[int](value=[6])
-        )
-        assert type(values["final_alias_result"]).__pydantic_generic_metadata__["args"] == (
-            Final[ListResult[int]],
-        )
-
-        assert values["dict_alias_result"] == GenericResult[dict[str, GenericContext[int]]](
-            value={"a": GenericContext[int](value=1)}
-        )
-        assert type(values["dict_alias_result"]).__pydantic_generic_metadata__["args"] == (
-            dict[str, GenericContext[int]],
-        )
-        assert type(values["dict_alias_result"].value["a"]).__pydantic_generic_metadata__["args"] == (int,)
-
-        assert values["union_result"] == GenericResult[GenericContext[int] | None](value=GenericContext[int](value=1))
-        assert type(values["union_result"].value).__pydantic_generic_metadata__["args"] == (int,)
-        """,
     )
+
+
+def _assert_ccflow_generic_payloads(encoded_payloads: dict[str, dict[str, str]]) -> None:
+    from collections.abc import Callable as AbcCallable
+    from typing import ClassVar, Final, List, Optional
+
+    import numpy as np
+
+    from ccflow import GenericContext, GenericResult
+    from ccflow.result import DictResult, ListResult
+    from ccflow.result.numpy import NumpyResult
+
+    values = _load_payloads(encoded_payloads)
+
+    assert values["standard_pickle_result"] == GenericResult[int](value=5)
+    assert type(values["standard_pickle_result"]).__pydantic_generic_metadata__["args"] == (int,)
+
+    assert values["generic_result"] == GenericResult[int](value=6)
+    assert values["generic_context"] == GenericContext[str](value="abc")
+    assert values["list_result"] == ListResult[int](value=[1, 2])
+    assert values["dict_result"] == DictResult[str, float](value={"a": 1.5})
+
+    assert type(values["numpy_result"]) is NumpyResult[np.float64]
+    np.testing.assert_array_equal(values["numpy_result"].array, np.array([1.0, 2.0], dtype=np.float64))
+
+    assert values["nested_result"] == GenericResult[ListResult[int]](value=ListResult[int](value=[1, 2]))
+    assert type(values["nested_result"]).__pydantic_generic_metadata__["args"] == (ListResult[int],)
+    assert type(values["nested_result"].value).__pydantic_generic_metadata__["args"] == (int,)
+
+    assert values["list_alias_result"] == GenericResult[list[ListResult[int]]](value=[ListResult[int](value=[1])])
+    assert type(values["list_alias_result"]).__pydantic_generic_metadata__["args"] == (list[ListResult[int]],)
+    assert type(values["list_alias_result"].value[0]).__pydantic_generic_metadata__["args"] == (int,)
+
+    assert values["typing_list_alias_result"] == GenericResult[List[ListResult[int]]](value=[ListResult[int](value=[2])])
+    assert type(values["typing_list_alias_result"]).__pydantic_generic_metadata__["args"] == (list[ListResult[int]],)
+
+    assert values["callable_alias_result"].value(ListResult[int](value=[1, 2, 3])) == 3
+    assert type(values["callable_alias_result"]).__pydantic_generic_metadata__["args"] == (AbcCallable[[ListResult[int]], int],)
+
+    assert values["optional_alias_result"] == GenericResult[Optional[ListResult[int]]](value=ListResult[int](value=[4]))
+    assert type(values["optional_alias_result"]).__pydantic_generic_metadata__["args"] == (Optional[ListResult[int]],)
+
+    assert values["classvar_alias_result"] == GenericResult[ClassVar[ListResult[int]]](value=ListResult[int](value=[5]))
+    assert type(values["classvar_alias_result"]).__pydantic_generic_metadata__["args"] == (ClassVar[ListResult[int]],)
+
+    assert values["final_alias_result"] == GenericResult[Final[ListResult[int]]](value=ListResult[int](value=[6]))
+    assert type(values["final_alias_result"]).__pydantic_generic_metadata__["args"] == (Final[ListResult[int]],)
+
+    assert values["dict_alias_result"] == GenericResult[dict[str, GenericContext[int]]](value={"a": GenericContext[int](value=1)})
+    assert type(values["dict_alias_result"]).__pydantic_generic_metadata__["args"] == (dict[str, GenericContext[int]],)
+    assert type(values["dict_alias_result"].value["a"]).__pydantic_generic_metadata__["args"] == (int,)
+
+    assert values["union_result"] == GenericResult[GenericContext[int] | None](value=GenericContext[int](value=1))
+    assert type(values["union_result"].value).__pydantic_generic_metadata__["args"] == (int,)
+
+
+def _assert_cold_ccflow_generic_payload_loads(spec: dict[str, str]) -> None:
+    import ccflow.result.generic as generic_module
+    from ccflow import GenericResult  # noqa: F401
+
+    had_specialization_before_load = hasattr(generic_module, "GenericResult[int]")
+    value = _load_payload(spec)
+    assert (
+        had_specialization_before_load,
+        value.value,
+        tuple(arg.__name__ for arg in type(value).__pydantic_generic_metadata__["args"]),
+    ) == (False, 6, ("int",))
+
+
+def _create_user_generic_payloads(module_dir: str) -> dict[str, dict[str, str]]:
+    import sys
+    from typing import Generic, TypeVar
+
+    from pydantic import PrivateAttr
+
+    from ccflow import BaseModel
+
+    sys.path.insert(0, module_dir)
+    from generic_user_model import UserBox
+
+    T = TypeVar("T")
+
+    class LocalBox(BaseModel, Generic[T]):
+        value: T
+        _bonus: int = PrivateAttr(default=1)
+
+    class LocalPayload(BaseModel):
+        value: int
+        _bonus: int = PrivateAttr(default=1)
+
+    importable = UserBox[int](value=2)
+    importable._bonus = 40
+    local_generic = LocalBox[int](value=3)
+    local_generic._bonus = 41
+    local_payload = LocalPayload(value=4)
+    local_payload._bonus = 42
+
+    return _serialize_payloads(
+        {
+            "importable_generic": ("cloudpickle", importable),
+            "local_generic": ("cloudpickle", local_generic),
+            "local_payload": ("cloudpickle", local_payload),
+        }
+    )
+
+
+def _assert_user_generic_payloads(encoded_payloads: dict[str, dict[str, str]], module_dir: str) -> None:
+    import sys
+
+    sys.path.insert(0, module_dir)
+    from generic_user_model import UserBox
+
+    values = _load_payloads(encoded_payloads)
+
+    assert type(values["importable_generic"]) is UserBox[int]
+    assert values["importable_generic"].value == 2
+    assert values["importable_generic"]._bonus == 40
+
+    assert values["local_generic"].value == 3
+    assert values["local_generic"]._bonus == 41
+    assert type(values["local_generic"]).__name__ == "LocalBox[int]"
+    assert type(values["local_generic"]).__pydantic_generic_metadata__["args"] == (int,)
+
+    assert values["local_payload"].value == 4
+    assert values["local_payload"]._bonus == 42
+    assert type(values["local_payload"]).__name__ == "LocalPayload"
+
+
+def _load_user_payload(spec: dict[str, str], module_dir: str):
+    import sys
+
+    sys.path.insert(0, module_dir)
+    return _load_payload(spec)
+
+
+def _load_user_payload_without_return(spec: dict[str, str], module_dir: str) -> None:
+    _load_user_payload(spec, module_dir)
+
+
+def _assert_payloads_load_in_spawned_process(
+    payload_factory,
+    assertion_worker,
+    *factory_args,
+    cold_loader_worker=_load_payload_without_return,
+) -> None:
+    # The bug only appears when the receiver has not already materialized the
+    # same Pydantic generic specialization. Create and load payloads in spawned
+    # subprocesses so the pytest process cannot warm the receiver's generic
+    # cache by accident.
+    encoded_payloads = _run_in_spawned_process(payload_factory, *factory_args)
+
+    # First load each payload in its own fresh process. The original bug was
+    # sensitive to whether a worker had already materialized the same generic
+    # specialization, so a shared loader process can create false positives.
+    for spec in encoded_payloads.values():
+        _run_in_spawned_process(cold_loader_worker, spec, *factory_args)
+
+    # Load in a second fresh process, then run all assertions there. Keeping many
+    # payloads in one process pair keeps detailed assertions cheap. The
+    # per-payload loop above already verifies cold-receiver loading.
+    _run_in_spawned_process(assertion_worker, encoded_payloads, *factory_args)
+
+
+def test_ccflow_generic_specializations_pickle_across_fresh_processes():
+    # One matrix test covers the ccflow-provided generic families and the hard
+    # type-argument shapes: nested Pydantic generics, builtin aliases containing
+    # Pydantic generics, and PEP 604 unions containing Pydantic generics.
+    _assert_payloads_load_in_spawned_process(_create_ccflow_generic_payloads, _assert_ccflow_generic_payloads)
+
+    encoded_payloads = _run_in_spawned_process(_create_ccflow_generic_payloads)
+    _run_in_spawned_process(_assert_cold_ccflow_generic_payload_loads, encoded_payloads["generic_result"])
 
 
 def test_user_generic_and_non_generic_ccflow_models_pickle_across_fresh_processes(tmp_path: Path):
@@ -226,96 +318,9 @@ def test_user_generic_and_non_generic_ccflow_models_pickle_across_fresh_processe
         )
     )
 
-    _assert_payloads_load_in_fresh_process(
-        f"""
-        import sys
-        from typing import Generic, TypeVar
-
-        from pydantic import PrivateAttr
-
-        from ccflow import BaseModel
-
-        sys.path.insert(0, {str(tmp_path)!r})
-        from generic_user_model import UserBox
-
-        T = TypeVar("T")
-
-        class LocalBox(BaseModel, Generic[T]):
-            value: T
-            _bonus: int = PrivateAttr(default=1)
-
-        class LocalPayload(BaseModel):
-            value: int
-            _bonus: int = PrivateAttr(default=1)
-
-        importable = UserBox[int](value=2)
-        importable._bonus = 40
-        local_generic = LocalBox[int](value=3)
-        local_generic._bonus = 41
-        local_payload = LocalPayload(value=4)
-        local_payload._bonus = 42
-
-        payloads = {{
-            "importable_generic": ("cloudpickle", importable),
-            "local_generic": ("cloudpickle", local_generic),
-            "local_payload": ("cloudpickle", local_payload),
-        }}
-        """,
-        """
-        from generic_user_model import UserBox
-
-        assert type(values["importable_generic"]) is UserBox[int]
-        assert values["importable_generic"].value == 2
-        assert values["importable_generic"]._bonus == 40
-
-        assert values["local_generic"].value == 3
-        assert values["local_generic"]._bonus == 41
-        assert type(values["local_generic"]).__name__ == "LocalBox[int]"
-        assert type(values["local_generic"]).__pydantic_generic_metadata__["args"] == (int,)
-
-        assert values["local_payload"].value == 4
-        assert values["local_payload"]._bonus == 42
-        assert type(values["local_payload"]).__name__ == "LocalPayload"
-        """,
-        extra_loader_setup=f"""
-        import sys
-        sys.path.insert(0, {str(tmp_path)!r})
-        """,
+    _assert_payloads_load_in_spawned_process(
+        _create_user_generic_payloads,
+        _assert_user_generic_payloads,
+        str(tmp_path),
+        cold_loader_worker=_load_user_payload_without_return,
     )
-
-
-def test_ccflow_generic_result_cloudpickle_in_ray_worker_without_receiver_materialization():
-    import ray
-
-    # Ray is the production-shaped failure mode: workers are fresh processes and
-    # may deserialize before ``GenericResult[int]`` has ever been created there.
-    payload = _create_payloads_in_fresh_process(
-        """
-        from ccflow import GenericResult
-
-        payloads = {"generic_result": ("cloudpickle", GenericResult[int](value=5))}
-        """
-    )["generic_result"]["payload"]
-
-    @ray.remote
-    def load_payload(encoded_payload: str):
-        import base64
-
-        import cloudpickle
-
-        import ccflow.result.generic as generic_module
-        from ccflow import GenericResult  # noqa: F401
-
-        # Importing the generic origin must not be enough to make the test pass.
-        # The worker should not know about ``GenericResult[int]`` until the
-        # reducer intentionally rebuilds it during cloudpickle.loads.
-        had_specialization_before_load = hasattr(generic_module, "GenericResult[int]")
-        value = cloudpickle.loads(base64.b64decode(encoded_payload))
-        return (
-            had_specialization_before_load,
-            value.value,
-            tuple(arg.__name__ for arg in type(value).__pydantic_generic_metadata__["args"]),
-        )
-
-    with ray.init(num_cpus=1):
-        assert ray.get(load_payload.remote(payload), timeout=30) == (False, 5, ("int",))

--- a/ccflow/tests/test_base_serialize.py
+++ b/ccflow/tests/test_base_serialize.py
@@ -1,15 +1,39 @@
 import pickle
 import platform
 import unittest
-from typing import Annotated, ClassVar, Dict, List, Optional, Type, Union
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Final,
+    Generic,
+    List,
+    NotRequired,
+    Optional,
+    Required,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 from packaging import version
 from pydantic import BaseModel as PydanticBaseModel, ConfigDict, Field, ValidationError
 
-from ccflow import BaseModel, NDArray
+from ccflow import BaseModel, CallableModelGenericType, GenericContext, GenericResult, NDArray, NullContext
+from ccflow.base import (
+    _GenericAliasTypeSpec,
+    _is_pydantic_generic_specialization,
+    _new_ccflow_generic_model,
+    _portable_generic_type_arg,
+    _PydanticGenericTypeSpec,
+    _restore_generic_type_arg,
+)
 from ccflow.enums import Enum
 from ccflow.exttypes.pydantic_numpy.ndtypes import bool_, complex64, float32, float64, int8, uint32
+from ccflow.result import ListResult
 from ccflow.serialization import make_ndarray_orjson_valid
 
 
@@ -96,6 +120,13 @@ class MultiAttributeModel(BaseModel):
     y: str
     x: float = Field(default=0.0)
     w: Annotated[bool, None]
+
+
+T = TypeVar("T")
+
+
+class GenericBox(BaseModel, Generic[T]):
+    value: T
 
 
 class TestBaseModelSerialization(unittest.TestCase):
@@ -270,3 +301,113 @@ class TestBaseModelSerialization(unittest.TestCase):
         self.assertEqual(serialized, target)
         deserialized = pickle.loads(serialized)
         self.assertEqual(model, deserialized)
+
+    def test_generic_pickle_override_guard_is_narrow(self):
+        # Blast radius check: the custom reducer should apply only to concrete
+        # Pydantic generic specializations. Ordinary BaseModel classes and
+        # unspecialized generic origins must keep Pydantic's default pickle
+        # behavior.
+        self.assertFalse(_is_pydantic_generic_specialization(ParentModel))
+        self.assertFalse(_is_pydantic_generic_specialization(GenericBox))
+        self.assertFalse(_is_pydantic_generic_specialization(GenericResult[int](value=5)))
+        self.assertTrue(_is_pydantic_generic_specialization(GenericBox[int]))
+        self.assertTrue(_is_pydantic_generic_specialization(GenericResult[int]))
+
+    def test_reduce_ex_only_takes_over_generic_specializations(self):
+        # This is the core blast-radius assertion for normal users: a non-generic
+        # model should not route through the ccflow generic restore helper at
+        # all. If this fails, the BaseModel pickle override became too broad.
+        non_generic_reduce = ParentModel(field1=1).__reduce_ex__(pickle.HIGHEST_PROTOCOL)
+        self.assertIsNot(non_generic_reduce[0], _new_ccflow_generic_model)
+
+        generic_model = GenericResult[int](value=5)
+        reduce_func, reduce_args, reduce_state = generic_model.__reduce_ex__(pickle.HIGHEST_PROTOCOL)
+
+        self.assertIs(reduce_func, _new_ccflow_generic_model)
+        origin, args = reduce_args
+        self.assertIs(origin, GenericResult)
+        self.assertEqual(args, (int,))
+        self.assertEqual(reduce_state, generic_model.__getstate__())
+
+        restored = reduce_func(*reduce_args)
+        restored.__setstate__(reduce_state)
+        self.assertEqual(restored, generic_model)
+        self.assertIs(type(restored), GenericResult[int])
+
+    def test_portable_generic_type_arg_only_wraps_fragile_type_arguments(self):
+        # The helper walks type arguments, not instance values. Plain importable
+        # args and generic aliases with only plain args stay unchanged, so the
+        # extra serialization shape is limited to aliases that actually contain
+        # runtime Pydantic generic specializations. This includes
+        # CallableModelGenericType annotations, which are themselves Pydantic
+        # generic specializations and can contain nested result specializations.
+        self.assertIs(_portable_generic_type_arg(int), int)
+        self.assertEqual(_portable_generic_type_arg(list[int]), list[int])
+
+        portable_model_arg = _portable_generic_type_arg(ListResult[int])
+        self.assertIsInstance(portable_model_arg, _PydanticGenericTypeSpec)
+        self.assertIs(_restore_generic_type_arg(portable_model_arg), ListResult[int])
+
+        portable_alias_arg = _portable_generic_type_arg(list[ListResult[int]])
+        self.assertIsInstance(portable_alias_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_alias_arg), list[ListResult[int]])
+
+        typing_list_alias = List[ListResult[int]]
+        portable_typing_alias_arg = _portable_generic_type_arg(typing_list_alias)
+        self.assertIsInstance(portable_typing_alias_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_typing_alias_arg), typing_list_alias)
+
+        callable_alias = Callable[[ListResult[int]], int]
+        portable_callable_alias_arg = _portable_generic_type_arg(callable_alias)
+        self.assertIsInstance(portable_callable_alias_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_callable_alias_arg), callable_alias)
+
+        portable_union_arg = _portable_generic_type_arg(GenericContext[int] | None)
+        self.assertIsInstance(portable_union_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_union_arg), GenericContext[int] | None)
+
+        optional_alias = Optional[ListResult[int]]
+        portable_optional_arg = _portable_generic_type_arg(optional_alias)
+        self.assertIsInstance(portable_optional_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_optional_arg), optional_alias)
+
+        classvar_alias = ClassVar[ListResult[int]]
+        portable_classvar_arg = _portable_generic_type_arg(classvar_alias)
+        self.assertIsInstance(portable_classvar_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_classvar_arg), classvar_alias)
+
+        final_alias = Final[ListResult[int]]
+        portable_final_arg = _portable_generic_type_arg(final_alias)
+        self.assertIsInstance(portable_final_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_final_arg), final_alias)
+
+        required_alias = Required[ListResult[int]]
+        portable_required_arg = _portable_generic_type_arg(required_alias)
+        self.assertIsInstance(portable_required_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_required_arg), required_alias)
+
+        not_required_alias = NotRequired[ListResult[int]]
+        portable_not_required_arg = _portable_generic_type_arg(not_required_alias)
+        self.assertIsInstance(portable_not_required_arg, _GenericAliasTypeSpec)
+        self.assertEqual(_restore_generic_type_arg(portable_not_required_arg), not_required_alias)
+
+        callable_annotation = CallableModelGenericType[NullContext, GenericResult[int]]
+        portable_callable_arg = _portable_generic_type_arg(callable_annotation)
+        self.assertIsInstance(portable_callable_arg, _PydanticGenericTypeSpec)
+        self.assertIs(_restore_generic_type_arg(portable_callable_arg), callable_annotation)
+
+    def test_generic_pickle_handles_all_pickle_protocols(self):
+        for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(protocol=protocol):
+                restored = pickle.loads(pickle.dumps(GenericResult[int](value=5), protocol=protocol))
+                self.assertEqual(restored, GenericResult[int](value=5))
+
+    def test_generic_pickle_preserves_outer_graph_identity_and_cycles(self):
+        shared = []
+        restored_shared = pickle.loads(pickle.dumps([GenericResult[Any](value=shared), shared], protocol=pickle.HIGHEST_PROTOCOL))
+        self.assertIs(restored_shared[0].value, restored_shared[1])
+
+        model = GenericResult[Any](value=None)
+        model.value = model
+        restored_cycle = pickle.loads(pickle.dumps(model, protocol=pickle.HIGHEST_PROTOCOL))
+        self.assertIs(restored_cycle.value, restored_cycle)

--- a/ccflow/tests/test_base_serialize.py
+++ b/ccflow/tests/test_base_serialize.py
@@ -3,10 +3,7 @@ import unittest
 from typing import (
     Annotated,
     Any,
-    Callable,
-    ClassVar,
     Dict,
-    Final,
     Generic,
     List,
     Optional,
@@ -15,20 +12,11 @@ from typing import (
 
 import numpy as np
 from pydantic import BaseModel as PydanticBaseModel, ConfigDict, Field, ValidationError
-from typing_extensions import NotRequired, Required
 
-from ccflow import BaseModel, CallableModelGenericType, GenericContext, GenericResult, NDArray, NullContext
-from ccflow.base import (
-    _GenericAliasTypeSpec,
-    _is_pydantic_generic_specialization,
-    _new_ccflow_generic_model,
-    _portable_generic_type_arg,
-    _PydanticGenericTypeSpec,
-    _restore_generic_type_arg,
-)
+from ccflow import BaseModel, GenericResult, NDArray
 from ccflow.enums import Enum
 from ccflow.exttypes.pydantic_numpy.ndtypes import bool_, complex64, float32, float64, int8, uint32
-from ccflow.result import ListResult
+from ccflow.pickling import reduce_generic_model_instance
 from ccflow.serialization import make_ndarray_orjson_valid
 
 
@@ -287,23 +275,24 @@ class TestBaseModelSerialization(unittest.TestCase):
         # Pydantic generic specializations. Ordinary BaseModel classes and
         # unspecialized generic origins must keep Pydantic's default pickle
         # behavior.
-        self.assertFalse(_is_pydantic_generic_specialization(ParentModel))
-        self.assertFalse(_is_pydantic_generic_specialization(GenericBox))
-        self.assertFalse(_is_pydantic_generic_specialization(GenericResult[int](value=5)))
-        self.assertTrue(_is_pydantic_generic_specialization(GenericBox[int]))
-        self.assertTrue(_is_pydantic_generic_specialization(GenericResult[int]))
+        self.assertIsNone(reduce_generic_model_instance(ParentModel(field1=1)))
+        self.assertIsNone(reduce_generic_model_instance(GenericBox(value=5)))
+        self.assertIsNone(reduce_generic_model_instance(GenericResult(value=5)))
+        self.assertIsNotNone(reduce_generic_model_instance(GenericBox[int](value=5)))
+        self.assertIsNotNone(reduce_generic_model_instance(GenericResult[int](value=5)))
 
     def test_reduce_ex_only_takes_over_generic_specializations(self):
         # This is the core blast-radius assertion for normal users: a non-generic
         # model should not route through the ccflow generic restore helper at
         # all. If this fails, the BaseModel pickle override became too broad.
-        non_generic_reduce = ParentModel(field1=1).__reduce_ex__(pickle.HIGHEST_PROTOCOL)
-        self.assertIsNot(non_generic_reduce[0], _new_ccflow_generic_model)
+        non_generic_model = ParentModel(field1=1)
+        self.assertIsNone(reduce_generic_model_instance(non_generic_model))
 
         generic_model = GenericResult[int](value=5)
-        reduce_func, reduce_args, reduce_state = generic_model.__reduce_ex__(pickle.HIGHEST_PROTOCOL)
+        reducer = reduce_generic_model_instance(generic_model)
+        self.assertIsNotNone(reducer)
+        reduce_func, reduce_args, reduce_state = reducer
 
-        self.assertIs(reduce_func, _new_ccflow_generic_model)
         origin, args = reduce_args
         self.assertIs(origin, GenericResult)
         self.assertEqual(args, (int,))
@@ -313,68 +302,6 @@ class TestBaseModelSerialization(unittest.TestCase):
         restored.__setstate__(reduce_state)
         self.assertEqual(restored, generic_model)
         self.assertIs(type(restored), GenericResult[int])
-
-    def test_portable_generic_type_arg_only_wraps_fragile_type_arguments(self):
-        # The helper walks type arguments, not instance values. Plain importable
-        # args and generic aliases with only plain args stay unchanged, so the
-        # extra serialization shape is limited to aliases that actually contain
-        # runtime Pydantic generic specializations. This includes
-        # CallableModelGenericType annotations, which are themselves Pydantic
-        # generic specializations and can contain nested result specializations.
-        self.assertIs(_portable_generic_type_arg(int), int)
-        self.assertEqual(_portable_generic_type_arg(list[int]), list[int])
-
-        portable_model_arg = _portable_generic_type_arg(ListResult[int])
-        self.assertIsInstance(portable_model_arg, _PydanticGenericTypeSpec)
-        self.assertIs(_restore_generic_type_arg(portable_model_arg), ListResult[int])
-
-        portable_alias_arg = _portable_generic_type_arg(list[ListResult[int]])
-        self.assertIsInstance(portable_alias_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_alias_arg), list[ListResult[int]])
-
-        typing_list_alias = List[ListResult[int]]
-        portable_typing_alias_arg = _portable_generic_type_arg(typing_list_alias)
-        self.assertIsInstance(portable_typing_alias_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_typing_alias_arg), typing_list_alias)
-
-        callable_alias = Callable[[ListResult[int]], int]
-        portable_callable_alias_arg = _portable_generic_type_arg(callable_alias)
-        self.assertIsInstance(portable_callable_alias_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_callable_alias_arg), callable_alias)
-
-        portable_union_arg = _portable_generic_type_arg(GenericContext[int] | None)
-        self.assertIsInstance(portable_union_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_union_arg), GenericContext[int] | None)
-
-        optional_alias = Optional[ListResult[int]]
-        portable_optional_arg = _portable_generic_type_arg(optional_alias)
-        self.assertIsInstance(portable_optional_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_optional_arg), optional_alias)
-
-        classvar_alias = ClassVar[ListResult[int]]
-        portable_classvar_arg = _portable_generic_type_arg(classvar_alias)
-        self.assertIsInstance(portable_classvar_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_classvar_arg), classvar_alias)
-
-        final_alias = Final[ListResult[int]]
-        portable_final_arg = _portable_generic_type_arg(final_alias)
-        self.assertIsInstance(portable_final_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_final_arg), final_alias)
-
-        required_alias = Required[ListResult[int]]
-        portable_required_arg = _portable_generic_type_arg(required_alias)
-        self.assertIsInstance(portable_required_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_required_arg), required_alias)
-
-        not_required_alias = NotRequired[ListResult[int]]
-        portable_not_required_arg = _portable_generic_type_arg(not_required_alias)
-        self.assertIsInstance(portable_not_required_arg, _GenericAliasTypeSpec)
-        self.assertEqual(_restore_generic_type_arg(portable_not_required_arg), not_required_alias)
-
-        callable_annotation = CallableModelGenericType[NullContext, GenericResult[int]]
-        portable_callable_arg = _portable_generic_type_arg(callable_annotation)
-        self.assertIsInstance(portable_callable_arg, _PydanticGenericTypeSpec)
-        self.assertIs(_restore_generic_type_arg(portable_callable_arg), callable_annotation)
 
     def test_generic_pickle_handles_all_pickle_protocols(self):
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):


### PR DESCRIPTION
# Pydantic Generic Pickle and Ray Notes

# TLDR

Concrete Pydantic generic `BaseModel` specializations can be fragile across
fresh-process pickle/cloudpickle boundaries. ccflow works around this for
concrete generic `ccflow.BaseModel` instances by pickling them as stable
`origin + args + state` data and recreating the specialized class during load.
Fixes #210.

## Summary

This issue is a mismatch between three things:

1. Python pickle prefers to reconstruct classes by importing a global module path.
2. Pydantic creates concrete generic model classes, such as `GenericResult[int]`, dynamically at runtime.
3. Ray workers are fresh processes and may unpickle an object before the same concrete generic class has been created in that worker.

The bug is not specific to `GenericResult`. Any concrete Pydantic generic `BaseModel` specialization can have the same problem if that specialized class object crosses a process boundary before the receiver has materialized it.

The fix is confusing because there are two separate objects involved:

- the model instance being pickled, such as `GenericResult[int](value=5)`
- the generated model class objects that may appear in the instance's class or
  generic type arguments, such as `GenericResult[int]`, `ListResult[int]`, or
  `CallableModelGenericType[NullContext, GenericResult[int]]`

Fixing only the top-level instance class is not enough if generated generic
classes are also embedded inside the type arguments that define that instance's
specialized class.

## What Pydantic Does

Pydantic v2 does not require `pydantic.generics.GenericModel`; normal `BaseModel` subclasses can be generic. When code evaluates:

```python
GenericResult[int]
```

Pydantic runs `BaseModel.__class_getitem__`. In the local environment, this is Pydantic `2.13.4`.
The relevant source is pinned to the `v2.13.4` tag here:
https://github.com/pydantic/pydantic/blob/v2.13.4/pydantic/main.py#L904-L969

The relevant flow is:

1. Check Pydantic's generic specialization cache.
2. Map type variables to concrete args.
3. Compute a parametrized model name, such as `GenericResult[int]`.
4. Call `_generics.create_generic_submodel(...)`.
5. Cache the generated class.
6. Return that generated class.

The generated class has metadata like:

```python
GenericResult[int].__pydantic_generic_metadata__
```

with shape:

```python
{
    "origin": GenericResult,
    "args": (int,),
    "parameters": (),
}
```

For module-level models like this repro, `origin` is stable and importable. In
general, the reducer still relies on the origin class itself being importable or
otherwise serializable by cloudpickle. The generated specialized class is
runtime-created.

In Pydantic's `_generics.create_generic_submodel`, the new subclass is created
with the origin model's `__module__` and generic metadata. The relevant source
is pinned here:
https://github.com/pydantic/pydantic/blob/v2.13.4/pydantic/_internal/_generics.py#L105-L149

```python
namespace = {"__module__": origin.__module__}
bases = (origin,)
...
created_model = meta(
    model_name,
    bases,
    namespace,
    __pydantic_generic_metadata__={
        "origin": origin,
        "args": args,
        "parameters": params,
    },
    ...
)
```

Then Pydantic conditionally registers the generated class in the origin module
when `_get_caller_frame_info(...)` decides the specialization was created from
a global context:
https://github.com/pydantic/pydantic/blob/v2.13.4/pydantic/_internal/_generics.py#L140-L147

```python
model_module, called_globally = _get_caller_frame_info(depth=3)
if called_globally:
    reference_module_globals = sys.modules[created_model.__module__].__dict__
    reference_module_globals.setdefault(reference_name, created_model)
```

That global registration is the key point. Sometimes a process has `ccflow.result.generic.GenericResult[int]` as a module attribute because that process already materialized it in a context Pydantic considers global. A fresh process may not.

## What Pickle and Cloudpickle Do

Pickle generally reconstructs class objects by global reference:

```text
module name + class name
```

For an ordinary class, this is fine:

```python
ccflow.result.generic.GenericResult
```

can be imported in any process.

For a generated specialization, pickle/cloudpickle may see:

```python
__module__ = "ccflow.result.generic"
__name__ = "GenericResult[int]"
```

and serialize it by reference as if this were importable:

```python
ccflow.result.generic.GenericResult[int]
```

That works in the process that created and registered the class. It can fail in a fresh process:

```text
AttributeError: Can't get attribute 'GenericResult[int]' on module 'ccflow.result.generic'
```

Ray makes this easy to hit because Ray workers are separate Python processes. Importing `GenericResult` in the worker does not necessarily create `GenericResult[int]`. If unpickling happens first, the generated class name is missing.

## Pydantic's Instance Pickle Behavior

Pydantic already has instance pickle machinery.

`BaseModel.__getstate__()` returns a dict containing Pydantic's internal model
state, and `BaseModel.__setstate__()` restores that state directly. The source
is pinned here:
https://github.com/pydantic/pydantic/blob/v2.13.4/pydantic/main.py#L1145-L1160

```python
{
    "__dict__": self.__dict__,
    "__pydantic_extra__": self.__pydantic_extra__,
    "__pydantic_fields_set__": self.__pydantic_fields_set__,
    "__pydantic_private__": private,
}
```

That is important because pickle should preserve an already-validated object. It should not rerun normal validation, coerce values again, drop private attrs, or rebuild the object through `model_validate`.

ccflow already overrides `__getstate__` / `__setstate__` slightly to make `__pydantic_fields_set__` deterministic in pickle output.

The new fix keeps this Pydantic state-based behavior. For concrete generic
specializations of `ccflow.BaseModel`, it changes only the reduce recipe.

## The Exact Failure

A minimal failing shape is:

```python
payload = cloudpickle.dumps(GenericResult[int](value=5))
```

Then in a fresh process that has imported `GenericResult` but has not evaluated `GenericResult[int]`:

```python
cloudpickle.loads(payload)
```

can fail because the receiver has the origin class:

```python
ccflow.result.generic.GenericResult
```

but not the generated specialization:

```python
ccflow.result.generic.GenericResult[int]
```

The problem is broader than the top-level class:

```python
GenericResult[ListResult[int]](...)
```

Here the top-level class is `GenericResult[ListResult[int]]`, and the generic arg contains another generated class, `ListResult[int]`.

This also appears inside typing aliases:

```python
GenericResult[list[ListResult[int]]](...)
GenericResult[typing.List[ListResult[int]]](...)
GenericResult[typing.Callable[[ListResult[int]], int]](...)
GenericResult[GenericContext[int] | None](...)
```

`typing.Callable` is especially annoying because its parameter types can appear as a plain Python list inside `typing.get_args()`:

```python
typing.get_args(Callable[[ListResult[int]], int])
# ([ListResult[int]], int)
```

So a helper that only walks `typing.get_args()` recursively can still miss generated classes inside that list.

Generated classes can also appear as field values:

```python
GenericResult[type](value=ListResult[int])
```

Even if the instance class is reconstructed correctly, the field value
`ListResult[int]` would otherwise be pickled by its fragile generated class
name. That field-value shape is not fixed by the current change. The current
fix deliberately covers generated classes used as the instance class and inside
generic type arguments, while leaving arbitrary class objects stored in model
state to pickle/cloudpickle's normal behavior.

## Pydantic-Only Repro

The smallest useful repro does not need ccflow or Ray. It only needs a plain
Pydantic generic model, two Python processes, and a cold receiver that imports
the generic origin class without first materializing the concrete specialization.

Consider the following repro:

```python
# /// script
# dependencies = [
#   "cloudpickle",
#   "pydantic>=2.6,<3",
# ]
# ///
"""Minimal Pydantic-only repro for generic BaseModel pickle lookup failures.

This intentionally does not import ccflow. It creates a normal importable module
containing a plain Pydantic generic model, pickles ``Box[int](...)`` in one
process, then tries to unpickle it in a second fresh process that imported
``Box`` but did not materialize ``Box[int]``.
"""

from __future__ import annotations

import base64
import subprocess
import sys
import tempfile
import textwrap
from pathlib import Path


def run_python(script: str) -> subprocess.CompletedProcess[str]:
    return subprocess.run(
        [sys.executable, "-c", textwrap.dedent(script)],
        capture_output=True,
        text=True,
        timeout=30,
    )


with tempfile.TemporaryDirectory() as temp_dir:
    root = Path(temp_dir)
    module_path = root / "pydantic_generic_model.py"
    module_path.write_text(
        textwrap.dedent(
            """
            from typing import Generic, TypeVar

            from pydantic import BaseModel

            T = TypeVar("T")

            class Box(BaseModel, Generic[T]):
                value: T
            """
        )
    )

    creator = run_python(
        f"""
        import base64
        import cloudpickle
        import pydantic
        import sys

        sys.path.insert(0, {str(root)!r})
        import pydantic_generic_model
        from pydantic_generic_model import Box

        print("pydantic_version=", pydantic.__version__)
        value = Box[int](value=5)
        print("creator_has_Box_int=", hasattr(pydantic_generic_model, "Box[int]"))
        print(base64.b64encode(cloudpickle.dumps(value, protocol=5)).decode())
        """
    )
    if creator.returncode != 0:
        raise SystemExit(creator.stderr)

    payload = creator.stdout.splitlines()[-1]
    print("=== creator ===")
    print("\n".join(creator.stdout.splitlines()[:-1]))

    cold_loader = run_python(
        f"""
        import base64
        import cloudpickle
        import sys

        sys.path.insert(0, {str(root)!r})
        import pydantic_generic_model
        from pydantic_generic_model import Box

        print("loader_has_Box_int_before=", hasattr(pydantic_generic_model, "Box[int]"))
        value = cloudpickle.loads(base64.b64decode({payload!r}))
        print(value)
        """
    )
    print("\n=== cold receiver: imports Box but not Box[int] ===")
    print("returncode:", cold_loader.returncode)
    print("stdout:")
    print(cold_loader.stdout.rstrip() or "<empty>")
    print("stderr:")
    print(cold_loader.stderr.rstrip() or "<empty>")

    warm_loader = run_python(
        f"""
        import base64
        import cloudpickle
        import sys

        sys.path.insert(0, {str(root)!r})
        import pydantic_generic_model
        from pydantic_generic_model import Box

        _ = Box[int]
        print("loader_has_Box_int_before=", hasattr(pydantic_generic_model, "Box[int]"))
        value = cloudpickle.loads(base64.b64decode({payload!r}))
        print(value)
        """
    )
    print("\n=== warm receiver: materializes Box[int] before load ===")
    print("returncode:", warm_loader.returncode)
    print("stdout:")
    print(warm_loader.stdout.rstrip() or "<empty>")
    print("stderr:")
    print(warm_loader.stderr.rstrip() or "<empty>")

```

Then it runs three subprocess steps:

1. A creator process imports `Box`, evaluates `Box[int]`, constructs
   `Box[int](value=5)`, and serializes it with `cloudpickle`.
2. A cold receiver process imports `Box` but does not evaluate `Box[int]`
   before calling `cloudpickle.loads(...)`.
3. A warm receiver process imports `Box`, evaluates `Box[int]`, then calls
   `cloudpickle.loads(...)`.

The observed output is:

```text
=== creator ===
pydantic_version= 2.13.4
creator_has_Box_int= True

=== cold receiver: imports Box but not Box[int] ===
returncode: 1
stdout:
loader_has_Box_int_before= False
stderr:
Traceback (most recent call last):
  File "<string>", line 11, in <module>
AttributeError: Can't get attribute 'Box[int]' on <module 'pydantic_generic_model' ...>

=== warm receiver: materializes Box[int] before load ===
returncode: 0
stdout:
loader_has_Box_int_before= True
value=5
stderr:
<empty>
```

That is the core bug in isolation. The creating process has a generated
`Box[int]` class registered on the module. The cold receiving process has only
the importable generic origin class `Box`, so pickle's global lookup for
`Box[int]` fails. The warm receiver evaluates `Box[int]` at module/global scope
before unpickling, which causes Pydantic to install the same generated class as
a module attribute before pickle tries to resolve it. That proves this is an
import/materialization-ordering problem rather than a ccflow model-definition
problem.

The same repro was checked with several Pydantic 2.x releases using:

```bash
uv run --with pydantic==<version> <pydantic-only-repro-script>
```

| Pydantic version | Cold receiver result | Warm receiver result |
| --- | --- | --- |
| 2.6.4 | fails with missing `Box[int]` module attribute | succeeds |
| 2.7.4 | fails with missing `Box[int]` module attribute | succeeds |
| 2.8.2 | fails with missing `Box[int]` module attribute | succeeds |
| 2.9.2 | fails with missing `Box[int]` module attribute | succeeds |
| 2.10.6 | fails with missing `Box[int]` module attribute | succeeds |
| 2.11.10 | fails with missing `Box[int]` module attribute | succeeds |
| 2.12.5 | fails with missing `Box[int]` module attribute | succeeds |
| 2.13.4 | fails with missing `Box[int]` module attribute | succeeds |

This is not a regression in a recent Pydantic minor release. The behavior is
stable across the tested 2.x line.

## Why the Fix Uses `__reduce_ex__`

`__reduce_ex__` is the pickle hook that returns a reconstruction recipe.

For concrete generic specializations of `ccflow.BaseModel`, ccflow now returns
a recipe like:

```python
(
    _new_ccflow_generic_model,
    (origin, portable_args),
    pydantic_state,
)
```

For:

```python
GenericResult[int](value=5)
```

the recipe is conceptually:

```python
origin = GenericResult
args = (int,)
state = self.__getstate__()
```

On load, pickle first calls the reducer function:

```python
cls = GenericResult[int]
obj = cls.__new__(cls)
```

Then, because the reducer returned `pydantic_state` as the third tuple element,
pickle applies that state to the object:

```python
obj.__setstate__(pydantic_state)
```

This uses Pydantic's own generic construction path in the receiving process,
while still letting pickle apply Pydantic's normal state protocol. The receiver
does not need to already have a global `GenericResult[int]` module attribute.

## Why Type Arguments Need Special Handling

The generic argument portability layer is the ugly part, but it is solving a
real second-order problem.

If we only serialize the top-level class as:

```python
origin + args
```

then this works:

```python
GenericResult[int](value=5)
```

but these can still fail:

```python
GenericResult[ListResult[int]](...)
GenericResult[list[ListResult[int]]](...)
GenericResult[Callable[[ListResult[int]], int]](...)
```

because `ListResult[int]` is itself a generated Pydantic generic class.

The helper therefore handles:

- generic type arguments
- typing aliases that contain generic type arguments
- `list` and `tuple` containers that can appear inside type expressions, such
  as the callable parameter list

The raw Pydantic state remains in the outer pickle stream. That is intentional:
pickle keeps its own memo table there, which is required to preserve shared
references, cycles, and protocol-5 buffers. The reducer only changes how the
generic class is recreated; it does not recursively rewrite arbitrary model
field/private state.

It intentionally does **not** treat model instances as type specs. A value like:

```python
ListResult[int](value=[1])
```

is still a model instance and should be pickled as an instance. Its own `__reduce_ex__` will handle its generated class. Accidentally converting instances into class specs would corrupt data.

## Blast Radius

There are two related guards:

```python
isinstance(value, type)
and value.__pydantic_generic_metadata__["origin"] is not None
```

That predicate identifies concrete generated Pydantic generic classes such as:

```python
GenericResult[int]
ListResult[str]
CallableModelGenericType[NullContext, GenericResult[int]]
```

The `BaseModel.__reduce_ex__` override runs when pickling a ccflow model
instance whose `type(self)` satisfies that predicate. So it **does** apply to:

```python
GenericResult[int](value=5)
```

It does **not** apply to:

```python
GenericResult
ParentModel
ParentModel(...)
```

Normal non-generic `BaseModel` instances continue using the default reducer
path, plus ccflow's existing deterministic `__getstate__` / `__setstate__`
hooks.

The custom reduce recipe is created only during pickling of concrete generic
ccflow `BaseModel` instances. It does not run during:

- normal construction
- validation
- `model_dump`
- equality
- compute/call paths
- registry lookup

The performance cost is therefore limited to pickling generic model instances.
The extra work is walking the generic type arguments for the model class. The
actual Pydantic instance state is still handled by the surrounding pickle
operation.

## Why Not Simpler Alternatives

### Why not call `model_validate` on restore?

Because pickle should restore object state, not validate new input.

Revalidation can:

- coerce values differently
- drop private attrs
- rerun validators with side effects
- fail if the current schema changed
- fail if the object was valid when created but no longer validates under newer code

Pydantic's own pickle support uses `__getstate__` / `__setstate__`, so the ccflow fix follows that model.

### Why not rely on cloudpickle to serialize the generated class by value?

Sometimes cloudpickle can serialize dynamic classes by value. But Pydantic specializations are not just ordinary dynamic classes. They carry generated schemas, validators, serializers, generic metadata, and cache behavior.

Also, if the class appears to be importable by module/name in the creating process, cloudpickle can choose a global-reference path. That is exactly the fragile path that fails in a fresh receiver.

The stable representation for a Pydantic generic specialization is not the generated class object. It is:

```python
origin class + generic args
```

### Why not globally register every generated specialization?

Pydantic already conditionally registers generated specializations when it thinks they were created globally. But a fresh Ray worker has not necessarily executed the same specialization expression yet.

Trying to eagerly register all possible specializations is impossible. Registering during serialization still would not help the receiver unless the receiver imports side effects in the same order.

### Why not monkeypatch pickle/cloudpickle for all classes?

Generated Pydantic specializations are class objects, so a global reducer would mean changing behavior for `type` or for broad classes of model classes. That is much wider than this bug.

The ccflow fix keeps the custom behavior inside ccflow `BaseModel` instance pickling.

### Why not support fields containing generated classes too?

That is a real broader issue, but fixing it at the state-value level is a much
bigger change. It requires intercepting arbitrary class objects inside the
pickle stream or walking Pydantic state manually, both of which can disturb
pickle's normal identity/cycle/buffer semantics if done carelessly.

The current fix chooses the smaller and safer boundary: generated classes that
define the model instance's own type, plus generated classes inside that type's
generic arguments. A field value like `GenericResult[type](value=ListResult[int])`
can still fail in a cold receiver and remains out of scope.

## How Broad Is This Problem?

It affects concrete Pydantic generic specializations crossing a process
boundary by pickle/cloudpickle when the receiver has not already materialized
the same specialization.

Shapes this PR fixes:

- instance class: `GenericResult[int](...)`
- nested generic arg: `GenericResult[ListResult[int]](...)`
- builtin alias arg: `GenericResult[list[ListResult[int]]](...)`
- dict alias arg: `GenericResult[dict[str, GenericContext[int]]](...)`
- `typing` alias arg: `GenericResult[typing.List[ListResult[int]]](...)`
- callable alias arg: `GenericResult[typing.Callable[[ListResult[int]], int]](...)`
- single-argument special-form args accepted by Pydantic in this context, such
  as `typing.ClassVar[ListResult[int]]` and `typing.Final[ListResult[int]]`
- union arg: `GenericResult[GenericContext[int] | None](...)`
- optional alias arg: `GenericResult[typing.Optional[ListResult[int]]](...)`

Not affected:

- non-generic `BaseModel` classes
- generic origin classes before parametrization, such as `GenericResult`
- normal runtime use that does not pickle

Handled by normal nested pickling, not by rewriting field/private state:

- generic ccflow model instances stored as field values; pickle visits those
  instances normally, and each instance's own reducer handles its generated
  class

Helper-level coverage only:

- `CallableModelGenericType[NullContext, GenericResult[int]]` as a type
  argument
- `typing.Required[ListResult[int]]` and
  `typing.NotRequired[ListResult[int]]`; Pydantic rejects these as
  `GenericResult[...]` arguments in this context, but the restore helper
  handles the one-argument special-form shape

Known not fixed:

- class-valued state such as `GenericResult[type](value=ListResult[int])`
- arbitrary metadata containers inside type expressions, such as
  `Annotated[int, frozenset([ListResult[int]])]`; the helper walks normal
  typing args plus explicit `list`/`tuple` containers, not every object that
  can be embedded in metadata

## Why This Is Hard To Read

The code is confusing because it has to preserve three different pieces of
pickle/type state:

1. Pydantic model instance state: restored through `__getstate__` / `__setstate__`
2. Pydantic generic class identity: restored through `origin[args]`
3. Python typing alias form: rebuilt as the same kind of type expression, such
   as builtin `list[...]`, `typing.List[...]`, `typing.Optional[...]`,
   `typing.Callable[...]`, or a PEP 604 `A | B` union

It also has to avoid a dangerous false positive:

```python
ListResult[int]          # generated class: make portable
ListResult[int](...)     # model instance: do not convert to a class spec
```

That is why there are separate helpers for:

- detecting concrete Pydantic generic specialization classes
- making generic type arguments portable
- restoring generic type arguments
- allocating the rebuilt generic model instance before pickle applies
  Pydantic's normal `__setstate__`

The resulting implementation is not aesthetically simple, but each piece exists to handle a real pickle/Ray failure mode.

## References

- Pydantic dynamic model docs. Pydantic explicitly notes that dynamically created models must be globally defined and have `__module__` provided to be pickleable:
  https://docs.pydantic.dev/latest/concepts/models/#dynamic-model-creation

- Pydantic `BaseModel.__class_getitem__` source for generic specialization:
  https://github.com/pydantic/pydantic/blob/v2.13.4/pydantic/main.py#L904-L969

- Pydantic `_generics.create_generic_submodel` source for dynamic generated
  generic subclasses and conditional module registration:
  https://github.com/pydantic/pydantic/blob/v2.13.4/pydantic/_internal/_generics.py#L105-L149

- Pydantic `BaseModel.__getstate__` / `BaseModel.__setstate__` source showing
  state-based pickle behavior:
  https://github.com/pydantic/pydantic/blob/v2.13.4/pydantic/main.py#L1145-L1160

- Pydantic issue #9668, broad background on Python compatibility work that mentions generic models and pickling among affected areas. It is not this exact bug:
  https://github.com/pydantic/pydantic/issues/9668

- Prefect's `add_cloudpickle_reduction`, an analogous downstream precedent for adding reducer logic around Pydantic model classes in workflow/distributed execution contexts:
  https://reference.prefect.io/prefect/utilities/pydantic/#add_cloudpickle_reduction
