### PR TITLE
UI extension improvements: sorting, registry path, field colors

### DIFF
--- a/ccflow/ui/model.py
+++ b/ccflow/ui/model.py
@@ -106,6 +106,7 @@ class ModelConfigViewer(param.Parameterized):
     def __init__(self, **params):
         super().__init__(**params)
 
+        self.model_path = ""
         self._metadata = pn.pane.HTML("", width=1200)
 
         self._layout = pn.Column(
@@ -152,6 +153,15 @@ class ModelConfigViewer(param.Parameterized):
             self._metadata.object = ""
             return
 
+        path_html = ""
+        if self.model_path:
+            path_html = f"""
+            <div style="margin-bottom:6px;">
+              <div style="font-weight:600;">Registry Path</div>
+              <code>{html.escape(self.model_path)}</code>
+            </div>
+            """
+
         description = model.meta.description.strip() if hasattr(model, "meta") and model.meta.description else ""
 
         desc_html = ""
@@ -169,7 +179,7 @@ class ModelConfigViewer(param.Parameterized):
             </div>
             """
 
-        self._metadata.object = desc_html + self._render_dependencies(model)
+        self._metadata.object = path_html + desc_html + self._render_dependencies(model)
 
 
 class ModelViewer(param.Parameterized):
@@ -181,6 +191,8 @@ class ModelViewer(param.Parameterized):
 
     def __init__(self, **params):
         super().__init__(**params)
+
+        self.model_path = ""
 
         # Sub-viewers (no JSONEditor inside)
         self._config_viewer = ModelConfigViewer()
@@ -231,6 +243,7 @@ class ModelViewer(param.Parameterized):
             return
 
         # Config tab
+        self._config_viewer.model_path = self.model_path
         self._config_viewer.model = model
         self._tabs.append(("Summary", self._config_viewer))
 

--- a/ccflow/ui/model.py
+++ b/ccflow/ui/model.py
@@ -142,7 +142,7 @@ class ModelConfigViewer(param.Parameterized):
         # Unique elements, sorted
         rows = sorted(set(all_paths))
 
-        items = "".join(f"<li>{html.escape(row)}</li>" for row in rows)
+        items = "".join(f"<li><code>{html.escape(row)}</code></li>" for row in rows)
 
         return f"""
         <div style="margin-top:8px;">

--- a/ccflow/ui/model.py
+++ b/ccflow/ui/model.py
@@ -16,9 +16,9 @@ __all__ = ("ModelTypeViewer", "ModelViewer", "ModelConfigViewer")
 
 
 _FIELD_STYLES = {
-    "name": "color:#0550ae;",
-    "type": "color:#8250df;",
-    "description": "color:#57606a;font-style:italic;",
+    "name": "color:#0550ae;",  # blue
+    "type": "color:#8250df;",  # purple
+    "description": "color:#57606a;font-style:italic;",  # muted gray
 }
 
 

--- a/ccflow/ui/model.py
+++ b/ccflow/ui/model.py
@@ -15,6 +15,13 @@ pn.extension("jsoneditor")
 __all__ = ("ModelTypeViewer", "ModelViewer", "ModelConfigViewer")
 
 
+_FIELD_STYLES = {
+    "name": "color:#0550ae;",
+    "type": "color:#8250df;",
+    "description": "color:#57606a;font-style:italic;",
+}
+
+
 class ModelTypeViewer(param.Parameterized):
     """
     Displays type name, class docstring, and fields for a Pydantic model type.
@@ -69,9 +76,10 @@ class ModelTypeViewer(param.Parameterized):
         for name, field in fields.items():
             field_type = display_as_type(field.annotation)
             desc = field.description or ""
-            field_items.append(
-                f"<li><code>{html.escape(name)}</code> (<code>{html.escape(field_type)}</code>){': ' + html.escape(desc) if desc else ''}</li>"
-            )
+            name_html = f'<code style="{_FIELD_STYLES["name"]}">{html.escape(name)}</code>'
+            type_html = f'<code style="{_FIELD_STYLES["type"]}">{html.escape(field_type)}</code>'
+            desc_html = f' — <span style="{_FIELD_STYLES["description"]}">{html.escape(desc)}</span>' if desc else ""
+            field_items.append(f"<li>{name_html} ({type_html}){desc_html}</li>")
 
         fields_html = ""
         if field_items:
@@ -88,7 +96,7 @@ class ModelTypeViewer(param.Parameterized):
         <div>
           <div style="margin-bottom:6px;">
             <span style="font-weight:600;">Type:</span>
-            <code>{html.escape(type_name)}</code>
+            <code style="{_FIELD_STYLES["type"]}">{html.escape(type_name)}</code>
           </div>
           {docs_html}
           {fields_html}

--- a/ccflow/ui/registry.py
+++ b/ccflow/ui/registry.py
@@ -60,7 +60,8 @@ class RegistryBrowser(param.Parameterized):
 
         model_items = registry.models.items()
         if self.sort_children:
-            model_items = sorted(model_items, key=lambda kv: kv[0])
+            # Subregistries first, then leaf models; each group sorted alphabetically.
+            model_items = sorted(model_items, key=lambda kv: (not isinstance(kv[1], ccflow.ModelRegistry), kv[0]))
 
         items = []
         for i, (name, model) in enumerate(model_items):

--- a/ccflow/ui/registry.py
+++ b/ccflow/ui/registry.py
@@ -21,6 +21,7 @@ class RegistryBrowser(param.Parameterized):
     def __init__(self, registry, **params):
         super().__init__(**params)
         self._registry = registry
+        self.selected_path = ""
 
         self._tree_items = self._build_tree(registry)
         self._node_index = self._build_node_index(self._tree_items)
@@ -84,6 +85,7 @@ class RegistryBrowser(param.Parameterized):
         def walk(items, prefix=""):
             for node in items:
                 path = f"{prefix}/{node['label']}" if prefix else node["label"]
+                node["_path"] = path
                 if "model" in node:
                     index[path] = node
                 walk(node.get("items", []), path)
@@ -109,7 +111,14 @@ class RegistryBrowser(param.Parameterized):
         self._search.value = ""
 
     def _on_tree_select(self, event):
-        self.selected_model = event.new[0].get("model") if event.new else None
+        if event.new:
+            node = event.new[0]
+            model = node.get("model")
+            self.selected_path = node.get("_path", "") if model is not None else ""
+            self.selected_model = model
+        else:
+            self.selected_path = ""
+            self.selected_model = None
 
 
 class ModelRegistryViewer(param.Parameterized):
@@ -157,6 +166,7 @@ class ModelRegistryViewer(param.Parameterized):
         # Wire browser → viewer and model param
         def _on_selection(e):
             self.model = e.new
+            self._viewer.model_path = self._browser.selected_path
             self._viewer.model = e.new
 
         self._browser.param.watch(_on_selection, "selected_model")

--- a/ccflow/ui/registry.py
+++ b/ccflow/ui/registry.py
@@ -13,6 +13,11 @@ __all__ = ("RegistryBrowser", "ModelRegistryViewer")
 class RegistryBrowser(param.Parameterized):
     selected_model = param.Parameter(default=None)
 
+    sort_children = param.Boolean(
+        default=False,
+        doc="If True, sort child entries alphabetically by name at every registry level. Defaults to insertion order.",
+    )
+
     def __init__(self, registry, **params):
         super().__init__(**params)
         self._registry = registry
@@ -52,8 +57,12 @@ class RegistryBrowser(param.Parameterized):
     def _build_tree(self, registry, index_prefix=()):
         import ccflow
 
+        model_items = registry.models.items()
+        if self.sort_children:
+            model_items = sorted(model_items, key=lambda kv: kv[0])
+
         items = []
-        for i, (name, model) in enumerate(registry.models.items()):
+        for i, (name, model) in enumerate(model_items):
             index_path = index_prefix + (i,)
             entry = {
                 "label": name,
@@ -133,11 +142,16 @@ class ModelRegistryViewer(param.Parameterized):
         doc="The currently selected model from the registry browser",
     )
 
+    sort_children = param.Boolean(
+        default=False,
+        doc="If True, sort registry child entries alphabetically by name at every level. Defaults to insertion order.",
+    )
+
     def __init__(self, registry, **params):
         super().__init__(**params)
 
         # Core components
-        self._browser = RegistryBrowser(registry)
+        self._browser = RegistryBrowser(registry, sort_children=self.sort_children)
         self._viewer = ModelViewer()
 
         # Wire browser → viewer and model param

--- a/ccflow/ui/registry.py
+++ b/ccflow/ui/registry.py
@@ -14,8 +14,8 @@ class RegistryBrowser(param.Parameterized):
     selected_model = param.Parameter(default=None)
 
     sort_children = param.Boolean(
-        default=False,
-        doc="If True, sort child entries alphabetically by name at every registry level. Defaults to insertion order.",
+        default=True,
+        doc="If True, sort child entries alphabetically by name at every registry level. Defaults to insertion order when False.",
     )
 
     def __init__(self, registry, **params):
@@ -152,8 +152,8 @@ class ModelRegistryViewer(param.Parameterized):
     )
 
     sort_children = param.Boolean(
-        default=False,
-        doc="If True, sort registry child entries alphabetically by name at every level. Defaults to insertion order.",
+        default=True,
+        doc="If True, sort registry child entries alphabetically by name at every level. Defaults to insertion order when False.",
     )
 
     def __init__(self, registry, **params):


### PR DESCRIPTION
Several small, independent improvements to the Panel-based UI extension in \`ccflow/ui/\`. All cosmetic / quality-of-life; no behavior changes outside the UI.

## Commits

- **Add \`sort_children\` option to \`RegistryBrowser\` UI extension.** Boolean param (default \`True\`) that sorts child entries alphabetically by name at every nested \`ModelRegistry\` level. Set to \`False\` to restore insertion order.
- **Display selected model's registry path in Summary tab.** Shows the full slash-separated registry path at the top of the Summary tab, formatted similarly to the existing Registry Dependencies section. Plumbed through as plain instance attributes (set in lockstep with each model assignment) so the existing model watcher renders both together.
- **Color-code field name, type, and description in Pydantic model viewer.** Tiny \`_FIELD_STYLES\` dict mapping kinds (\`name\`, \`type\`, \`description\`) to inline CSS, applied in \`ModelTypeViewer\`'s field list and the top "Type:" line. Light syntax-highlighting palette (blue / purple / muted-italic gray). Extending is one dict entry.
- **Default \`sort_children\` to \`True\`** on both \`RegistryBrowser\` and \`ModelRegistryViewer\` so children render alphabetically out of the box.
- **Sort subregistries before models** when \`sort_children\` is enabled — file-browser style: subregistries (alphabetical) first, then leaf models (alphabetical).
- **Render registry dependencies in monospace** for visual consistency with the new Registry Path display above them.

## Not in this PR

A separate follow-up will tackle viewport-scaling and a draggable sidebar/main divider via \`pmui.Page\`. Tracking that on its own branch.