### PR TITLE
Make registry viewer autosize to viewport with resizable sidebar

### DIFF
--- a/ccflow/tests/ui/test_cli.py
+++ b/ccflow/tests/ui/test_cli.py
@@ -28,8 +28,7 @@ class TestGetUIArgsParser:
 
         # Viewer-specific
         assert hasattr(args, "browser_width")
-        assert hasattr(args, "browser_height")
-        assert hasattr(args, "viewer_width")
+        assert hasattr(args, "title")
 
     def test_viewer_layout_defaults(self):
         """Test default values for viewer-specific arguments."""
@@ -37,8 +36,7 @@ class TestGetUIArgsParser:
         args = parser.parse_args([])
 
         assert args.browser_width == 400
-        assert args.browser_height == 700
-        assert args.viewer_width is None
+        assert args.title == "ccflow Model Registry"
 
     def test_viewer_layout_custom_values(self):
         """Test setting custom values for viewer layout arguments."""
@@ -47,16 +45,13 @@ class TestGetUIArgsParser:
             [
                 "--browser-width",
                 "500",
-                "--browser-height",
-                "800",
-                "--viewer-width",
-                "600",
+                "--title",
+                "My Registry",
             ]
         )
 
         assert args.browser_width == 500
-        assert args.browser_height == 800
-        assert args.viewer_width == 600
+        assert args.title == "My Registry"
 
     def test_overrides_positional(self):
         """Test overrides are captured as positional arguments."""

--- a/ccflow/tests/ui/test_registry.py
+++ b/ccflow/tests/ui/test_registry.py
@@ -246,26 +246,31 @@ class TestModelRegistryViewer:
         panel = viewer.__panel__()
         assert isinstance(panel, pn.viewable.Viewable)
 
-    def test_panel_is_row_layout(self):
-        """Test that the panel is a Row layout (browser + viewer side by side)."""
+    def test_panel_is_page_layout(self):
+        """Test that the panel is a pmui.Page (viewport-filling layout with resizable sidebar)."""
+        import panel_material_ui as pmui
+
         registry = ModelRegistry(name="test")
         viewer = ModelRegistryViewer(registry)
         panel = viewer.__panel__()
-        assert isinstance(panel, pn.Row)
+        assert isinstance(panel, pmui.Page)
+        assert panel.sidebar_width == viewer.browser_width
+        assert panel.title == viewer.title
 
     def test_init_with_custom_dimensions(self):
-        """Test initialization with custom width/height."""
+        """Test initialization with custom sidebar width and title."""
         registry = ModelRegistry(name="test")
         viewer = ModelRegistryViewer(
             registry,
             browser_width=500,
-            browser_height=800,
-            viewer_width=600,
+            title="My Registry",
         )
 
         assert viewer.browser_width == 500
-        assert viewer.browser_height == 800
-        assert viewer.viewer_width == 600
+        assert viewer.title == "My Registry"
+        panel = viewer.__panel__()
+        assert panel.sidebar_width == 500
+        assert panel.title == "My Registry"
 
     def test_browser_viewer_wiring(self):
         """Test that browser selection updates viewer."""
@@ -282,42 +287,12 @@ class TestModelRegistryViewer:
         assert viewer._viewer.model == model
 
     def test_default_browser_dimensions(self):
-        """Test default browser dimensions."""
+        """Test default browser width and title."""
         registry = ModelRegistry(name="test")
         viewer = ModelRegistryViewer(registry)
 
         assert viewer.browser_width == 400
-        assert viewer.browser_height == 700
-        assert viewer.viewer_width is None
-
-    def test_make_browser_column(self):
-        """Test _make_browser_column creates proper column."""
-        registry = ModelRegistry(name="test")
-        viewer = ModelRegistryViewer(registry)
-
-        column = viewer._make_browser_column()
-        assert isinstance(column, pn.Column)
-        assert column.width == viewer.browser_width
-        assert column.height == viewer.browser_height
-        assert column.scroll is True
-
-    def test_make_viewer_column_with_width(self):
-        """Test _make_viewer_column with specified width."""
-        registry = ModelRegistry(name="test")
-        viewer = ModelRegistryViewer(registry, viewer_width=600)
-
-        column = viewer._make_viewer_column()
-        assert isinstance(column, pn.Column)
-        assert column.width == 600
-
-    def test_make_viewer_column_without_width(self):
-        """Test _make_viewer_column without specified width (stretch)."""
-        registry = ModelRegistry(name="test")
-        viewer = ModelRegistryViewer(registry)
-
-        column = viewer._make_viewer_column()
-        assert isinstance(column, pn.Column)
-        assert column.sizing_mode == "stretch_width"
+        assert viewer.title == "ccflow Model Registry"
 
     def test_model_param_default_none(self):
         """Test that model param starts as None."""

--- a/ccflow/ui/cli.py
+++ b/ccflow/ui/cli.py
@@ -31,19 +31,13 @@ def _get_ui_args_parser() -> argparse.ArgumentParser:
         "--browser-width",
         type=int,
         default=400,
-        help="Width of the registry browser panel (default: 400)",
+        help="Initial width of the registry browser sidebar (default: 400). User can drag to resize.",
     )
     parser.add_argument(
-        "--browser-height",
-        type=int,
-        default=700,
-        help="Height of the registry browser panel (default: 700)",
-    )
-    parser.add_argument(
-        "--viewer-width",
-        type=int,
-        default=None,
-        help="Fixed width for model viewer panel (default: stretch)",
+        "--title",
+        type=str,
+        default="ccflow Model Registry",
+        help="Title shown in the page header (default: 'ccflow Model Registry')",
     )
 
     return parser
@@ -91,8 +85,7 @@ def registry_viewer_cli(
         viewer = ModelRegistryViewer(
             registry,
             browser_width=args.browser_width,
-            browser_height=args.browser_height,
-            viewer_width=args.viewer_width,
+            title=args.title,
         )
         return viewer.__panel__()
 

--- a/ccflow/ui/model.py
+++ b/ccflow/ui/model.py
@@ -32,9 +32,10 @@ class ModelTypeViewer(param.Parameterized):
     def __init__(self, **params):
         super().__init__(**params)
 
-        self._pane = pn.pane.HTML("", width=1200)
+        self._pane = pn.pane.HTML("", sizing_mode="stretch_width")
         self._layout = pn.Column(
             self._pane,
+            sizing_mode="stretch_width",
         )
 
         self.param.watch(self._on_type_change, "model_type")
@@ -79,7 +80,7 @@ class ModelTypeViewer(param.Parameterized):
             name_html = f'<code style="{_FIELD_STYLES["name"]}">{html.escape(name)}</code>'
             type_html = f'<code style="{_FIELD_STYLES["type"]}">{html.escape(field_type)}</code>'
             desc_html = f' — <span style="{_FIELD_STYLES["description"]}">{html.escape(desc)}</span>' if desc else ""
-            field_items.append(f"<li>{name_html} ({type_html}){desc_html}</li>")
+            field_items.append(f'<li style="overflow-wrap:anywhere;">{name_html} ({type_html}){desc_html}</li>')
 
         fields_html = ""
         if field_items:
@@ -96,7 +97,7 @@ class ModelTypeViewer(param.Parameterized):
         <div>
           <div style="margin-bottom:6px;">
             <span style="font-weight:600;">Type:</span>
-            <code style="{_FIELD_STYLES["type"]}">{html.escape(type_name)}</code>
+            <code style="{_FIELD_STYLES["type"]}overflow-wrap:anywhere;">{html.escape(type_name)}</code>
           </div>
           {docs_html}
           {fields_html}
@@ -115,10 +116,11 @@ class ModelConfigViewer(param.Parameterized):
         super().__init__(**params)
 
         self.model_path = ""
-        self._metadata = pn.pane.HTML("", width=1200)
+        self._metadata = pn.pane.HTML("", sizing_mode="stretch_width")
 
         self._layout = pn.Column(
             self._metadata,
+            sizing_mode="stretch_width",
         )
 
         self.param.watch(self._on_model_change, "model")
@@ -142,7 +144,7 @@ class ModelConfigViewer(param.Parameterized):
         # Unique elements, sorted
         rows = sorted(set(all_paths))
 
-        items = "".join(f"<li><code>{html.escape(row)}</code></li>" for row in rows)
+        items = "".join(f'<li><code style="overflow-wrap:anywhere;">{html.escape(row)}</code></li>' for row in rows)
 
         return f"""
         <div style="margin-top:8px;">
@@ -219,13 +221,15 @@ class ModelViewer(param.Parameterized):
             value={},
             mode="view",
             menu=False,
-            width=600,
+            sizing_mode="stretch_width",
+            min_width=400,
         )
 
         self._json_container = pn.Column(
             "## Parameters",
             self._json_editor,
             visible=False,  # hidden initially
+            sizing_mode="stretch_width",
         )
 
         self._layout = pn.Column(
@@ -233,6 +237,7 @@ class ModelViewer(param.Parameterized):
             self._tabs,
             pn.Spacer(height=12),
             self._json_container,
+            sizing_mode="stretch_width",
         )
 
         self.param.watch(self._on_model_change, "model")

--- a/ccflow/ui/registry.py
+++ b/ccflow/ui/registry.py
@@ -125,26 +125,19 @@ class RegistryBrowser(param.Parameterized):
 class ModelRegistryViewer(param.Parameterized):
     """
     Top-level viewer that composes the RegistryBrowser and ModelViewer
-    into a scrollable two-panel layout.
+    into a viewport-filling page with a resizable sidebar.
     """
 
     # Layout parameters
     browser_width = param.Integer(
         default=400,
         bounds=(200, None),
-        doc="Width of the registry browser panel (px)",
+        doc="Initial width of the registry browser sidebar (px). User can drag to resize at runtime.",
     )
 
-    browser_height = param.Integer(
-        default=700,
-        bounds=(300, None),
-        doc="Height of the registry browser panel (px)",
-    )
-
-    viewer_width = param.Integer(
-        default=None,
-        allow_None=True,
-        doc="Optional fixed width for the model viewer panel (px)",
+    title = param.String(
+        default="ccflow Model Registry",
+        doc="Title shown in the page header.",
     )
 
     model = param.Parameter(
@@ -172,33 +165,19 @@ class ModelRegistryViewer(param.Parameterized):
 
         self._browser.param.watch(_on_selection, "selected_model")
 
-        # Build layout
-        self._layout = pn.Row(
-            self._make_browser_column(),
-            self._make_viewer_column(),
+        # Wrap browser in a scrolling Column so large registries remain navigable.
+        sidebar_panel = pn.Column(
+            self._browser,
+            sizing_mode="stretch_both",
+            scroll=True,
+        )
+
+        self._layout = pmui.Page(
+            sidebar=[sidebar_panel],
+            main=[self._viewer],
+            sidebar_width=self.browser_width,
+            title=self.title,
         )
 
     def __panel__(self):
         return self._layout
-
-    # Internal helpers
-
-    def _make_browser_column(self):
-        return pn.Column(
-            self._browser,
-            width=self.browser_width,
-            height=self.browser_height,
-            scroll=True,  # ✅ only left panel scrolls
-        )
-
-    def _make_viewer_column(self):
-        if self.viewer_width is not None:
-            return pn.Column(
-                self._viewer,
-                width=self.viewer_width,
-            )
-        else:
-            return pn.Column(
-                self._viewer,
-                sizing_mode="stretch_width",
-            )


### PR DESCRIPTION
Replaces the fixed-pixel ``pn.Row`` layout in the ``ccflow.ui`` registry viewer with a ``panel_material_ui.Page`` that fills the viewport and provides a draggable sidebar/main divider out of the box.

## Changes
- ``ModelRegistryViewer.__panel__()`` now returns a ``pmui.Page`` with the registry browser in the sidebar and the model viewer in the main slot.
- Inner widgets that had hardcoded pixel widths (``ModelTypeViewer._pane``, ``ModelConfigViewer._metadata``, ``ModelViewer._json_editor``) now use ``sizing_mode='stretch_width'`` and the stretch is propagated through their parent Columns.
- ``JSONEditor`` gets ``min_width=400`` to guard against the known zero-width-when-initially-hidden measurement bug.
- ``overflow-wrap:anywhere`` added to ``<code>``/``<li>`` blocks that render long type names, paths, and field rows so they wrap instead of forcing horizontal overflow when the sidebar is narrowed.
- The browser is wrapped in a scrolling ``pn.Column(..., sizing_mode='stretch_both', scroll=True)`` inside the sidebar so large registries remain navigable.

## Hard breaks
- ``ModelRegistryViewer`` params ``browser_height`` and ``viewer_width`` removed.
- CLI flags ``--browser-height`` and ``--viewer-width`` removed.
- New ``title`` param + ``--title`` flag for the page header (default ``"ccflow Model Registry"``).

## Notebook usage note
``pmui.Page`` is a template — designed to be the root of a served document, not embedded inline in a Jupyter output cell. For interactive inline inspection of a registry or model use the existing ``BaseModel.get_widget()`` (``IPython.display.JSON``). For the full interactive UI, run the CLI or ``pn.serve(viewer.__panel__())`` / ``viewer.__panel__().show()``.

## Verification
- ``make lint`` clean.
- All 68 tests in ``ccflow/tests/ui/`` pass.
- Reviewed by a GPT-5.5 ``code-review`` agent; one finding (unwrapped field-list ``<code>`` blocks) addressed before commit.
- Smoke-tested via ``panel serve`` against a registry with nested subregistries and long field names — sidebar resize, scroll, and content wrapping all behave as expected.