### PR TITLE
Restore NullContext as a distinct class with virtual subclass semantics

### DIFF
--- a/ccflow/context.py
+++ b/ccflow/context.py
@@ -86,8 +86,38 @@ __all__ = (
 
 _SEPARATOR = ","
 
-# Starting 0.8.0 Nullcontext is an alias to ContextBase
-NullContext = ContextBase
+
+class _NullContextMeta(type(ContextBase)):
+    """Metaclass that makes ``NullContext`` (and only ``NullContext``) a virtual superclass
+    of every ``ContextBase`` subclass.
+
+    A model annotated ``context: NullContext`` should accept any context. We achieve that
+    by lying in ``isinstance`` / ``issubclass`` while keeping ``NullContext`` a distinct
+    class so that introspection (``.context_type.__name__``, docstring, schema title)
+    reports ``NullContext`` rather than ``ContextBase``.
+
+    The lie applies only when the comparison target is ``NullContext`` itself; user-defined
+    subclasses of ``NullContext`` fall through to normal class-hierarchy rules.
+    """
+
+    def __instancecheck__(cls, obj):
+        if cls is globals().get("NullContext"):
+            return isinstance(type(obj), type) and ContextBase in type(obj).__mro__
+        return super().__instancecheck__(obj)
+
+    def __subclasscheck__(cls, sub):
+        if cls is globals().get("NullContext"):
+            return isinstance(sub, type) and ContextBase in sub.__mro__
+        return super().__subclasscheck__(sub)
+
+
+class NullContext(ContextBase, metaclass=_NullContextMeta):
+    """A Null Context, used when no context is required.
+
+    Any context can be passed where a NullContext is expected, but the model
+    should not rely on any of its fields.
+    """
+
 
 C = TypeVar("C", bound=Hashable)
 


### PR DESCRIPTION
## Problem

`NullContext` is currently aliased to `ContextBase` (commit fc64400, PR #166). This preserved substitutability (any context can be passed where `NullContext` is expected) but degraded introspection: for a model declaring `context: NullContext`, `.context_type.__name__` reports `"ContextBase"` with the abstract base's docstring, which is confusing for users.

## Approach

Reintroduce `NullContext` as a distinct subclass of `ContextBase` with a metaclass that lies in `__instancecheck__` / `__subclasscheck__`: any `ContextBase` instance or subclass virtually satisfies `NullContext`. The lie is gated to `NullContext` itself, so user-defined subclasses of `NullContext` follow normal class-hierarchy rules.

Pydantic v2's instance fast-path in `model_validate` respects the lie, so original context instances flow through unchanged — same as the alias today.

## Behavior

| | Before (alias) | After (this PR) |
|---|---|---|
| `m.context_type.__name__` | `ContextBase` | `NullContext` ✅ |
| docstring | `ContextBase`'s | `NullContext`'s ✅ |
| `isinstance(date_ctx, NullContext)` | True | True |
| `m(date_ctx)` on `NullContext` model | passes through unchanged | passes through unchanged |
| `MyNull(NullContext)` subclass behaves as plain subclass | yes | yes (gating) |
| Polymorphic `type_` discriminator | `ContextBase` | `NullContext` |

## Tests

All 841 tests pass on the local suite. No existing tests required modification.

## Cache invalidation note

`tokenize(NullContext())` differs from `tokenize(ContextBase())` (the discriminator value changes). Any persisted cache keyed under the old alias semantics will miss once on first re-evaluation. Not a correctness issue, just a one-time invalidation worth a release note.