### PR TITLE
Workaround for pyright bug on ccflow.BaseModel subclasses

### DIFF
--- a/ccflow/base.py
+++ b/ccflow/base.py
@@ -165,26 +165,28 @@ def _adjust_annotations(annotation):
 
 class _SerializeAsAnyMeta(ModelMetaclass):
     def __new__(self, name: str, bases: Tuple[type], namespaces: Dict[str, Any], **kwargs):
-        annotations = _namespace_annotations(namespaces)
+        # The metaclass must be referenced statically on BaseModel so that pyright
+        # recognizes it as a pydantic ModelMetaclass and synthesizes __init__ with
+        # field defaults. On pydantic >= 2.13 the annotation rewrite is unnecessary,
+        # so we gate it here rather than swapping the metaclass.
+        if not _USE_RUNTIME_POLYMORPHIC_SERIALIZATION:
+            annotations = _namespace_annotations(namespaces)
 
-        for base in bases:
-            for base_ in base.__mro__:
-                if base_ is PydanticBaseModel:
-                    annotations.update(base_.__annotations__)
+            for base in bases:
+                for base_ in base.__mro__:
+                    if base_ is PydanticBaseModel:
+                        annotations.update(base_.__annotations__)
 
-        for field, annotation in annotations.items():
-            if not field.startswith("__"):
-                annotations[field] = _adjust_annotations(annotation)
+            for field, annotation in annotations.items():
+                if not field.startswith("__"):
+                    annotations[field] = _adjust_annotations(annotation)
 
-        namespaces["__annotations__"] = annotations
+            namespaces["__annotations__"] = annotations
 
         return super().__new__(self, name, bases, namespaces, **kwargs)
 
 
-_BASE_MODEL_METACLASS = ModelMetaclass if _USE_RUNTIME_POLYMORPHIC_SERIALIZATION else _SerializeAsAnyMeta
-
-
-class BaseModel(PydanticBaseModel, _RegistryMixin, metaclass=_BASE_MODEL_METACLASS):
+class BaseModel(PydanticBaseModel, _RegistryMixin, metaclass=_SerializeAsAnyMeta):
     """BaseModel is a base class for all pydantic models within the ccflow framework.
 
     This gives us a way to add functionality to the framework, including


### PR DESCRIPTION
A user reported that on v0.8.4, running pyright over

```python
import ccflow
ccflow.FlowOptions()
```

fails with:

```
error: Arguments missing for parameters "log_level", "verbose", "validate_result", "volatile", "cacheable", "evaluator" (reportCallIssue)
```

even though all those fields have defaults. v0.8.3 was clean.

The cause is the conditional metaclass introduced in #215 for pydantic 2.13 compat:

```python
_BASE_MODEL_METACLASS = ModelMetaclass if _USE_RUNTIME_POLYMORPHIC_SERIALIZATION else _SerializeAsAnyMeta

class BaseModel(PydanticBaseModel, _RegistryMixin, metaclass=_BASE_MODEL_METACLASS):
    ...
```

Pyright can't resolve a metaclass picked at runtime, so it stops synthesizing the pydantic `__init__` and every field with a default ends up looking required. This affects every `ccflow.BaseModel` subclass, not just `FlowOptions`.

Fix: keep the metaclass statically declared as `_SerializeAsAnyMeta` and move the `_USE_RUNTIME_POLYMORPHIC_SERIALIZATION` gate one level inward, into the body of `_SerializeAsAnyMeta.__new__`. On pydantic ≥ 2.13 the metaclass is now a thin pass-through over `ModelMetaclass`; on older pydantic the annotation rewrite still runs as before.

Verified:
- `python -m pyright repro.py` → 0 errors
- `pytest ccflow/tests/test_base_serialize.py ccflow/tests/test_base_cloudpickle.py` → all pass
