### PR TITLE
docs: note on non-transparent wrapper evaluators under GraphEvaluator

### DIFF
--- a/docs/wiki/how-to/Cache-Results.md
+++ b/docs/wiki/how-to/Cache-Results.md
@@ -131,6 +131,30 @@ with FlowOptionsOverride(options={"cacheable": True, "evaluator": MyEvaluator()}
 
 Custom evaluators can run models on other platforms (Dask, Ray, Spark), implement other caching backends (Redis, S3), or add batching and custom logging.
 
+### Non-transparent wrappers under a `GraphEvaluator`
+
+The example above is *transparent* — it returns `context()` unchanged. If instead your evaluator **reshapes, replaces, or publishes** the result (so `is_transparent` returns `False`), be careful when it runs alongside a `GraphEvaluator`. The graph re-drives the **same** evaluator stack for two extra kinds of invocation, and a wrapper that fires on every call misbehaves on both:
+
+- **`__deps__` resolution.** To discover the graph, the model's `__deps__` is evaluated through the same stack. Its result is a `GraphDepList`, not a model result — reshaping logic (e.g. touching `.df`) crashes on it.
+- **Dependency (child) evaluations.** Each child node is evaluated through the stack too. A wrapper that side-effects there will run on results it should not own, publishing more than once and changing cache identity so it no longer matches the true compute.
+
+Gate on the function being evaluated so the wrapper only acts on a model's own `__call__`, never on `__deps__`:
+
+```python
+class PublishingEvaluator(EvaluatorBase):
+    def is_transparent(self, context: ModelEvaluationContext) -> bool:
+        return False
+
+    def __call__(self, context: ModelEvaluationContext) -> ResultType:
+        if context.fn != "__call__":
+            return context()  # e.g. __deps__ resolution — pass straight through
+        result = context()
+        publish(result)       # reshape / publish only the real model result
+        return result
+```
+
+The `fn` guard stops the `__deps__` crash. To also stop the wrapper from firing on **dependencies**, scope the override to the models it should act on rather than applying it globally — `FlowOptionsOverride(options=..., models=(root_model,))` (or `model_types=(...)`), exactly as in [Choose which models are retried](Retry-on-Failure#choose-which-models-are-retried). Scope alone is not enough: a model still re-drives *its own* `__deps__`, so the `fn == "__call__"` guard is always required. The built-in `DryRunEvaluator` (`ccflow/evaluators/dry_run.py`) is a worked example — it passes through on `__deps__` and uses a re-entry guard so it does not re-act on child drives during traversal.
+
 ## See also
 
 - [Retry on Failure](Retry-on-Failure) — the retry evaluator and `RetryModel`.


### PR DESCRIPTION
## Summary

Adds a docs subsection to the **"Write a custom evaluator"** how-to (`docs/wiki/how-to/Cache-Results.md`) covering a subtle footgun when a **non-transparent wrapper evaluator** (one that reshapes, replaces, or publishes the result) is combined with `GraphEvaluator`.

`GraphEvaluator` re-drives both `__deps__` resolution and child-node evaluations through the *same* evaluator stack. A wrapper that fires on every invocation therefore:

- runs on the `GraphDepList` payload of `__deps__` (not a model result) — reshaping logic such as `.df` access crashes there; and
- side-effects on dependency results it should not own — double-publishing and changing cache identity so it no longer matches the true compute.

## What the note says

- Gate the wrapper on `context.fn == "__call__"` so it never acts on `__deps__` (includes a small `PublishingEvaluator` example).
- Scope the override to specific `models` / `model_types` to avoid firing on dependencies — but note this is **not sufficient on its own**, because a model still re-drives its *own* `__deps__`, so the `fn == "__call__"` guard is always required.
- Points at the built-in `DryRunEvaluator` as a worked example (passes through on `__deps__`, uses a re-entry guard for child drives).

The findings were verified empirically against a `GraphEvaluator` stack.

## Notes

- Docs-only change; no code changes.
- `mdformat --check` and `codespell` pass.
