### PR TITLE
Replace httpx with httpx2 in examples

### DIFF
--- a/ccflow/examples/etl/models.py
+++ b/ccflow/examples/etl/models.py
@@ -3,7 +3,7 @@ from csv import DictReader, DictWriter
 from io import StringIO
 
 from bs4 import BeautifulSoup
-from httpx import Client
+from httpx2 import Client
 from pydantic import Field
 
 from ccflow import CallableModel, ContextBase, Flow, GenericResult, NullContext

--- a/docs/wiki/how-to/Retry-on-Failure.md
+++ b/docs/wiki/how-to/Retry-on-Failure.md
@@ -27,7 +27,7 @@ with FlowOptionsOverride(options={"evaluator": retry}):
 `max_delay` caps the *cumulative* sleep time between retries (not total runtime): once the next backoff would push accumulated waiting over the budget, no further retries happen. Use `retry_exceptions` / `no_retry_exceptions` to choose which exceptions are retried.
 
 > [!NOTE]
-> `retry_exceptions` and `no_retry_exceptions` accept either a bare exception class (as above) or an importable path string (e.g. `"httpx.ConnectError"`, the form for YAML/Hydra configs). Paths are imported eagerly, so a third-party exception requires that package installed.
+> `retry_exceptions` and `no_retry_exceptions` accept either a bare exception class (as above) or an importable path string (e.g. `"httpx2.ConnectError"`, the form for YAML/Hydra configs). Paths are imported eagerly, so a third-party exception requires that package installed.
 
 The evaluator is transparent (a successful result is identical to a direct call, so caching and dependency graphs are unaffected) and holds no per-call state, so one instance is safe to share across threads and combine with parallel evaluators. Place it *inside* a parallel evaluator to retry each task independently, or *outside* to retry the whole dispatch as a unit.
 

--- a/docs/wiki/tutorials/Building-an-ETL-Pipeline.md
+++ b/docs/wiki/tutorials/Building-an-ETL-Pipeline.md
@@ -38,7 +38,7 @@ The extract step queries a site over HTTP and returns its HTML:
 
 ```python
 from typing import Optional
-from httpx import Client
+from httpx2 import Client
 from ccflow import CallableModel, Flow, GenericResult
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ develop = [
     "opentelemetry-api",
     # Test deps
     "beautifulsoup4",
-    "httpx",
+    "httpx2",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
@@ -110,7 +110,7 @@ develop = [
 ]
 test = [
     "beautifulsoup4",
-    "httpx",
+    "httpx2",
     "opentelemetry-api",
     "pytest",
     "pytest-asyncio",


### PR DESCRIPTION
## Description

Replace httpx with httpx2 in ETL examples, related documentation, and example test dependencies.

The four non-CLI ETL example tests pass. The CLI test remains blocked by the existing missing Hydra callable/extract config, before HTTP code runs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (Ruff on changed Python)
- [x] Tests pass (four non-CLI ETL example tests)
- [ ] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [x] Changelog / version bump (not applicable)