### PR TITLE
Fix unsynchronised access to `FlowOptionsOverride._OPEN_OVERRIDES`

### DIFF
--- a/ccflow/callable.py
+++ b/ccflow/callable.py
@@ -13,6 +13,7 @@ which all need to be defined together so that pydantic (especially V1) can resol
 
 import abc
 import logging
+import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache, wraps
@@ -380,6 +381,12 @@ class FlowOptionsDeps(FlowOptions):
     _deps: bool = PrivateAttr(True)
 
 
+# Guards FlowOptionsOverride._OPEN_OVERRIDES. Reentrant because get_options can be re-entered on the
+# same thread: its loop bodies call isinstance(), which may run a user __instancecheck__ that opens a
+# further override. Kept as a module global, not a ClassVar, so cloudpickle never copies it by value.
+_OPEN_OVERRIDES_LOCK = threading.RLock()
+
+
 class FlowOptionsOverride(BaseModel):
     """This python context helps the registry track dependencies of underlying calls to the registry.
 
@@ -413,7 +420,13 @@ class FlowOptionsOverride(BaseModel):
             model_options: Additional options to inject in the overrides
         """
         current_options = _FLOW_OPTIONS.model_copy()
-        for override in cls._OPEN_OVERRIDES.values():  # noqa: F402
+        # Take a single snapshot under the lock and use it for both loops below. The loop bodies
+        # call isinstance(), which can run arbitrary user code that re-enters FlowOptionsOverride,
+        # so the lock must not be held across them. A second snapshot would let the two loops
+        # disagree about which overrides are open.
+        with _OPEN_OVERRIDES_LOCK:
+            overrides = list(cls._OPEN_OVERRIDES.values())
+        for override in overrides:  # noqa: F402
             # Apply global options first
             if not override.models and not override.model_types:
                 current_options = cls._apply_options(current_options, override.options)
@@ -429,21 +442,23 @@ class FlowOptionsOverride(BaseModel):
         if model.meta.options:
             current_options = model.meta.options
         # Then apply all model-specific overrides
-        for override in cls._OPEN_OVERRIDES.values():
+        for override in overrides:
             if any(model is m for m in override.models) or isinstance(model, override.model_types):
                 current_options = cls._apply_options(current_options, override.options)
         return current_options
 
     def __enter__(self):
         override_id = id(self)
-        if override_id in FlowOptionsOverride._OPEN_OVERRIDES:
-            raise ValueError(f"{self} has already been entered.")
-        FlowOptionsOverride._OPEN_OVERRIDES[override_id] = self
+        with _OPEN_OVERRIDES_LOCK:
+            if override_id in FlowOptionsOverride._OPEN_OVERRIDES:
+                raise ValueError(f"{self} has already been entered.")
+            FlowOptionsOverride._OPEN_OVERRIDES[override_id] = self
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         override_id = id(self)
-        del FlowOptionsOverride._OPEN_OVERRIDES[override_id]
+        with _OPEN_OVERRIDES_LOCK:
+            del FlowOptionsOverride._OPEN_OVERRIDES[override_id]
 
 
 class Flow(PydanticBaseModel):

--- a/ccflow/tests/test_decorator.py
+++ b/ccflow/tests/test_decorator.py
@@ -1,6 +1,9 @@
 import logging
+import threading
 from datetime import date, datetime
 from unittest import TestCase
+
+import cloudpickle
 
 from ccflow import CallableModel, DateContext, EvaluatorBase, Flow, FlowOptions, FlowOptionsOverride, GenericResult, ModelEvaluationContext
 
@@ -218,6 +221,13 @@ class TestMetaData(TestCase):
 
 
 class TestFlowOptionsOverride(TestCase):
+    def setUp(self):
+        # A leaked override would silently change the options seen by unrelated tests.
+        FlowOptionsOverride._OPEN_OVERRIDES.clear()
+
+    def tearDown(self):
+        FlowOptionsOverride._OPEN_OVERRIDES.clear()
+
     def test_global(self):
         model = DefaultModel()
         get_options = DefaultModel.__call__.get_options
@@ -317,3 +327,141 @@ class TestFlowOptionsOverride(TestCase):
             self.assertEqual(get_options(model), new_options)
             self.assertEqual(MyModel.bar.get_options(model), new_options)
             self.assertEqual(MyModel.baz.get_options(model), new_baz_options)
+
+    def test_reentrant_instancecheck(self):
+        """get_options must tolerate a user __instancecheck__ that opens another override.
+
+        get_options calls isinstance(model, override.model_types) from inside its own
+        iteration over _OPEN_OVERRIDES, so a user-defined __instancecheck__ runs
+        mid-iteration and may legitimately enter a further override. Iterating the
+        dict directly raised RuntimeError: dictionary changed size during iteration.
+        """
+        opened = []
+
+        class ReentrantMeta(type(CallableModel)):
+            def __instancecheck__(cls, instance):
+                if not opened:
+                    nested = FlowOptionsOverride(options=FlowOptions(log_level=logging.ERROR))
+                    nested.__enter__()
+                    opened.append(nested)
+                return super().__instancecheck__(instance)
+
+        class ReentrantModel(DefaultModel, metaclass=ReentrantMeta):
+            pass
+
+        model = DefaultModel()
+        get_options = DefaultModel.__call__.get_options
+        new_options = FlowOptions(log_level=logging.INFO)
+        try:
+            with FlowOptionsOverride(options=new_options, model_types=(ReentrantModel,)):
+                options = get_options(model)
+        finally:
+            for nested in opened:
+                nested.__exit__(None, None, None)
+
+        self.assertTrue(opened, "the __instancecheck__ hook never ran, so the test is not exercising the bug")
+        self.assertIsInstance(options, FlowOptions)
+
+    def test_concurrent_override_entry(self):
+        """Entering an override on another thread must not break an in-flight get_options.
+
+        The interleaving is pinned with a barrier rather than left to chance: the reader
+        is parked inside its iteration over _OPEN_OVERRIDES until the writer has entered
+        a new override.
+        """
+        barrier = threading.Barrier(2, timeout=30)
+
+        class BlockingMeta(type(CallableModel)):
+            def __instancecheck__(cls, instance):
+                barrier.wait()  # let the writer mutate the dict
+                barrier.wait()  # resume only once it has
+                return super().__instancecheck__(instance)
+
+        class BlockingModel(DefaultModel, metaclass=BlockingMeta):
+            pass
+
+        model = DefaultModel()
+        get_options = DefaultModel.__call__.get_options
+        reader_error = []
+        writer_override = FlowOptionsOverride(options=FlowOptions(log_level=logging.ERROR))
+
+        def reader():
+            try:
+                get_options(model)
+            except BaseException as exc:  # noqa: BLE001 - surfaced on the main thread below
+                reader_error.append(exc)
+
+        def writer():
+            try:
+                barrier.wait()
+                writer_override.__enter__()
+            finally:
+                barrier.wait()
+
+        with FlowOptionsOverride(options=FlowOptions(log_level=logging.INFO), model_types=(BlockingModel,)):
+            threads = [threading.Thread(target=reader), threading.Thread(target=writer)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=30)
+            if id(writer_override) in FlowOptionsOverride._OPEN_OVERRIDES:
+                writer_override.__exit__(None, None, None)
+
+        self.assertEqual(reader_error, [], "get_options raised while another thread entered an override")
+
+    def test_lock_is_a_module_global(self):
+        """The lock guarding _OPEN_OVERRIDES must not live on the class.
+
+        cloudpickle serialises a class by value when it cannot reference it by module
+        path, copying its __dict__ wholesale. A lock held as a ClassVar would then be
+        dragged into the payload and fail with "cannot pickle '_thread.RLock' object".
+        Keeping it as a module global makes that impossible: there is no class attribute
+        for a subclass to inherit or redefine.
+        """
+        import ccflow.callable as callable_module
+
+        self.assertIsInstance(callable_module._OPEN_OVERRIDES_LOCK, type(threading.RLock()))
+        for klass in FlowOptionsOverride.__mro__:
+            self.assertNotIn("_OPEN_OVERRIDES_LOCK", vars(klass))
+
+    def test_cloudpickle_instance(self):
+        """An override instance must survive a cloudpickle round trip."""
+        override = FlowOptionsOverride(options=FlowOptions(log_level=logging.INFO))
+        restored = cloudpickle.loads(cloudpickle.dumps(override))
+        self.assertEqual(restored.options.log_level, override.options.log_level)
+
+    def test_cloudpickle_class(self):
+        """The FlowOptionsOverride class itself must survive a round trip, by reference."""
+        self.assertIs(cloudpickle.loads(cloudpickle.dumps(FlowOptionsOverride)), FlowOptionsOverride)
+
+    def test_cloudpickle_subclass_by_value(self):
+        """A subclass that cloudpickle must serialise by value must still round trip.
+
+        A class defined inside a function cannot be referenced by module path, so
+        cloudpickle copies its __dict__ wholesale. This is the case that fails if the
+        lock is stored on the class, and it is the one that matters under ray.
+        """
+
+        class LocalOverride(FlowOptionsOverride):
+            pass
+
+        self.assertIn("<locals>", LocalOverride.__qualname__)
+        restored = cloudpickle.loads(cloudpickle.dumps(LocalOverride))
+        self.assertEqual(restored.__name__, "LocalOverride")
+        self.assertTrue(issubclass(restored, FlowOptionsOverride))
+
+    def test_cloudpickle_closure_with_open_override(self):
+        """A closure capturing an entered override must survive a round trip.
+
+        This mirrors how work is shipped to a ray worker: a callable is captured while
+        an override is open on the submitting side.
+        """
+        with FlowOptionsOverride(options=FlowOptions(log_level=logging.INFO)) as override:
+
+            def use_override():
+                return override.options.log_level
+
+            expected = override.options.log_level
+            restored = cloudpickle.loads(cloudpickle.dumps(use_override))
+
+        self.assertEqual(restored(), expected)


### PR DESCRIPTION
## Problem

`FlowOptionsOverride` tracks every open override in a process-global plain `dict`
(`_OPEN_OVERRIDES`). That dict is mutated in `__enter__` and `__exit__` and iterated in
`get_options` — twice — with no synchronisation anywhere in `ccflow/callable.py`.

Any mutation that lands while `get_options` is part-way through one of its loops raises:

```
RuntimeError: dictionary changed size during iteration
```

This is reachable two ways, and the first one needs no concurrency at all.

### 1. Single-threaded re-entrancy

The second loop calls `isinstance(model, override.model_types)` *inside* the iteration:

```python
for override in cls._OPEN_OVERRIDES.values():
    if any(model is m for m in override.models) or isinstance(model, override.model_types):
        current_options = cls._apply_options(current_options, override.options)
```

`isinstance` dispatches to a user-supplied `__instancecheck__`, so arbitrary user code runs
mid-iteration. If that code opens another `FlowOptionsOverride` — entirely legal, and not
obviously dangerous from the caller's point of view — the dict changes size while the loop is
live. Reproduces 100% of the time, in one thread, with no timing involved.

### 2. Concurrent access from multiple threads

Any second thread entering or leaving an override while another thread is inside `get_options`
produces the identical failure.

This is not hypothetical. It was encountered via a query engine that invokes Python data
sources on several OS threads within a single process. Each concurrent invocation re-entered
ccflow and called `get_options`, while overrides were being opened and closed on other threads.

That path is also unusually hard to diagnose, which is the main reason this PR carries a long
description rather than a one-line change. The engine catches the exception at the Python
boundary and re-raises it as its own generic error, so the `RuntimeError` never appears in the
surfaced traceback. What the user sees points at the data source, not at ccflow, at
`FlowOptionsOverride`, or at shared mutable state. It is also load-dependent — it only fires
once thread count and timing line up, so it presents as an intermittent failure that vanishes
under a debugger.

## Fix

Add a reentrant module-level lock, guard both mutation sites, and have `get_options` take a
single snapshot under the lock that both loops then iterate.

Four details are deliberate:

1. **`RLock`, not `Lock`.** The single-threaded re-entrancy path above means the same thread can
   arrive back at the lock while already holding it. A plain `Lock` would deadlock.

2. **The lock is not held across the loop bodies.** Those bodies call `isinstance`, which can run
   arbitrary user code that re-enters `FlowOptionsOverride`. Snapshot under the lock, release,
   then iterate.

3. **One snapshot, not two.** Taking a separate snapshot per loop would reintroduce a torn read:
   the two loops could disagree about which overrides are open, so a global override could be
   applied while its model-scoped counterpart is missed, or vice versa. That is a silent
   wrong-answer bug — strictly worse than the crash being fixed.

4. **A module global, not a `ClassVar`.** See below.

### Why the lock is a module global rather than a `ClassVar`

The natural placement is on the class, next to the state it guards. That was the first
implementation, and it was rejected for two reasons.

First, there is no correct annotation. `threading.RLock` is a factory *function*, not a class, so
`ClassVar[threading.RLock]` is not a valid type expression — it merely survives at runtime
because `typing` does not validate the subscript. The spelling that does typecheck reaches into
the private `threading._RLock`. A module global needs no annotation at all.

Second, and more important for this library: a lock on the class is a cloudpickle hazard.
cloudpickle serialises a class *by value*, copying its `__dict__` wholesale, whenever it cannot
reference that class by module path — which is the case for `__main__`-scoped and function-local
classes. An unpicklable object in that `__dict__` then breaks serialisation with
`TypeError: cannot pickle '_thread.RLock' object`.

Measured against a `ClassVar` build of this fix:

| Scenario | `ClassVar` lock |
|---|---|
| Override instance via cloudpickle | OK — lock not in payload |
| `FlowOptionsOverride` class itself | OK — pickled by reference |
| By-value subclass that only *inherits* the lock | OK — not in its own `__dict__` |
| By-value subclass that *redefines* the lock | **FAILS** — `TypeError` above |
| Closure holding an open override | OK |

Only the last-but-one case breaks, so a `ClassVar` would in fact have been safe on every path
ccflow itself takes. But ccflow users subclass its models and ship them to ray workers, and
leaving an avoidable trap there seemed wrong.

A module global removes the hazard structurally rather than probabilistically: module globals are
resolved by reference at unpickle time and are never copied into a subclass's `__dict__`, so
there is no class attribute for a subclass to inherit or redefine in the first place. It also
matches the existing convention — `ccflow/base.py` already declares `_LAZY_COORDINATION_LOCK` as
a module-level `RLock`, and `_FLOW_OPTIONS` in this same file is a private module-level singleton
of exactly this shape.

### Why not `threading.local`

Worth stating explicitly, since it is the fix a reader may reach for first: `_OPEN_OVERRIDES`
must not become a `threading.local`.

The visibility of open overrides to worker threads is load-bearing, not incidental. Callers open
an override on one thread — for example to install a specific evaluator — and rely on work
dispatched to worker threads observing it. Under `threading.local`, worker threads would see an
empty override set and silently fall back to the default options. In the case that surfaced this
bug, that would mean worker threads stop seeing a configured caching evaluator and bypass the
cache entirely: no error, no warning, just a silent correctness and performance regression.

Trading a loud, immediately visible `RuntimeError` for silent wrong behaviour is a strictly worse
outcome. The dict is shared on purpose; it needs a lock, not thread-confinement.

## Tests

Six tests added to the existing `TestFlowOptionsOverride` in `ccflow/tests/test_decorator.py`,
alongside the tests that already cover this class.

Both concurrency tests are deterministic by construction, not probabilistic — there are no
sleeps and no reliance on timing, so neither can be flaky in CI:

- `test_reentrant_instancecheck` — the single-threaded case, driven through a metaclass
  `__instancecheck__`. No threads at all.
- `test_concurrent_override_entry` — the two-thread case, with the interleaving pinned by a
  `threading.Barrier` so the reader is parked *inside* its iteration until the writer has
  mutated the dict.

Four cloudpickle tests lock in the serialisation properties described above, including a
function-local subclass that asserts `"<locals>" in __qualname__` to prove cloudpickle really is
serialising by value rather than by reference.

`setUp`/`tearDown` clear `_OPEN_OVERRIDES`, which also protects the six pre-existing tests in
this class from contamination by a leaked override.

## Verification

- Full suite: **1358 passed, 2 skipped**.
- Reverting only `callable.py` and re-running: **3 failed, 23 passed** — precisely the three new
  behavioural tests, each failing on its own assertion rather than on a collection error.
- `ruff check` and `ruff format --check`: clean.
- `ty check`: unchanged from the pre-existing baseline diagnostic count.