### PR TITLE
Remove decorative comment separators

### DIFF
--- a/ccflow/examples/tpch/config/conf.yaml
+++ b/ccflow/examples/tpch/config/conf.yaml
@@ -24,19 +24,15 @@
 #      (``load_config(overrides=["tpch.backend.scale_factor=1.0"])``) reconfigures
 #      every table, answer and query consistently.
 
-# ---------------------------------------------------------------------------
 # Shared DuckDB backend. Plain ``ccflow.BaseModel`` — not callable itself,
 # but registered so all providers share one connection and one ``dbgen`` call.
-# ---------------------------------------------------------------------------
 tpch:
   backend:
     _target_: ccflow.examples.tpch.TPCHDuckDBBackend
     scale_factor: 0.1
 
-# ---------------------------------------------------------------------------
 # Per-table providers. One instance per TPC-H table; the output schema of
 # each instance is fixed by its ``table`` field.
-# ---------------------------------------------------------------------------
 table:
   customer:
     _target_: ccflow.examples.tpch.TPCHTableProvider
@@ -71,10 +67,8 @@ table:
     backend: /tpch/backend
     table: supplier
 
-# ---------------------------------------------------------------------------
 # Reference answers, one per query, served straight from DuckDB's
 # ``tpch_answers()`` table at the configured scale factor.
-# ---------------------------------------------------------------------------
 answer:
   Q1:
     _target_: ccflow.examples.tpch.TPCHAnswerProvider
@@ -165,12 +159,10 @@ answer:
     backend: /tpch/backend
     query_id: 22
 
-# ---------------------------------------------------------------------------
 # The 22 TPC-H queries. Each ``TPCHQuery`` is the same Python class with a
 # different ``query_id`` and a different tuple of table-provider inputs.
 # Wiring the inputs in YAML makes each query's table dependencies explicit
 # and overridable per-query.
-# ---------------------------------------------------------------------------
 query:
   Q1:
     _target_: ccflow.examples.tpch.TPCHQuery

--- a/ccflow/flow_model.py
+++ b/ccflow/flow_model.py
@@ -118,9 +118,7 @@ __all__ = (
 _AnyCallable = Callable[..., Any]
 
 
-# ---------------------------------------------------------------------------
 # Internal data structures
-# ---------------------------------------------------------------------------
 
 
 class _UnsetFlowInput:
@@ -393,9 +391,7 @@ class _LocalFlowModelPicklePayload(NamedTuple):
     factory_kwargs: dict[str, Any]
 
 
-# ---------------------------------------------------------------------------
 # Small value helpers
-# ---------------------------------------------------------------------------
 
 
 def _context_values(context: ContextBase) -> dict[str, Any]:
@@ -469,9 +465,7 @@ def _concrete_context_type(context_type: Any) -> type[ContextBase] | None:
     return None
 
 
-# ---------------------------------------------------------------------------
 # Type coercion, lazy thunks, and registry references
-# ---------------------------------------------------------------------------
 
 
 def _remember_type_adapter(cache: "OrderedDict[Any, Any]", key: Any, value: Any) -> Any:
@@ -670,9 +664,7 @@ def _ensure_named_python_function(fn: _AnyCallable, *, decorator_name: str) -> N
         raise TypeError(f"{decorator_name} only supports named Python functions.")
 
 
-# ---------------------------------------------------------------------------
 # Context-transform serialization and generated-model persistence
-# ---------------------------------------------------------------------------
 
 
 def _serialize_context_transform_config(config: _FlowModelConfig) -> str:
@@ -867,9 +859,7 @@ def _register_generated_model_class(config: _FlowModelConfig, generated_cls: typ
     )
 
 
-# ---------------------------------------------------------------------------
 # Runtime context contracts and dependency projection
-# ---------------------------------------------------------------------------
 
 
 def _runtime_context_for_model(model: CallableModel, values: dict[str, Any]) -> ContextBase:
@@ -1026,9 +1016,7 @@ def _missing_regular_param_names(model: "_GeneratedFlowModelBase", config: _Flow
     return missing
 
 
-# ---------------------------------------------------------------------------
 # Generated model input resolution
-# ---------------------------------------------------------------------------
 
 
 def _resolve_regular_param_value(model: "_GeneratedFlowModelBase", param: _FlowModelParam, context: ContextBase) -> Any:
@@ -1470,9 +1458,7 @@ def _coerce_model_context_value(model: CallableModel, field_name: str, value: An
     return _coerce_value(field_name, value, contract.input_types[field_name], source)
 
 
-# ---------------------------------------------------------------------------
 # Effective identity helpers
-# ---------------------------------------------------------------------------
 
 # Identity terms used below:
 # - config identity: stable hash of the analyzed Flow.model contract, fixed at
@@ -1843,9 +1829,7 @@ def _generated_model_identity_payload(
     )
 
 
-# ---------------------------------------------------------------------------
 # Static binding resolution and with_context normalization
-# ---------------------------------------------------------------------------
 
 
 def _resolved_static_contextual_values(
@@ -2104,9 +2088,7 @@ def _normalize_with_context(model: CallableModel, patches: tuple[Any, ...], fiel
     return _validate_static_context_spec_declared_context(model, context_spec)
 
 
-# ---------------------------------------------------------------------------
 # Bound context application and compute context construction
-# ---------------------------------------------------------------------------
 
 
 def _context_from_values_preserving_private_state(context: ContextBase, values: dict[str, Any]) -> ContextBase:
@@ -2537,9 +2519,7 @@ def _recursive_dependency_specs_for_flow(
         active.remove(model_id)
 
 
-# ---------------------------------------------------------------------------
 # model.flow API and BoundModel wrapper
-# ---------------------------------------------------------------------------
 
 
 class FlowAPI:
@@ -3158,9 +3138,7 @@ class _GeneratedFlowModelBase(CallableModel):
         return _generated_model_identity_payload(self, context)
 
 
-# ---------------------------------------------------------------------------
 # Generated model method builders and decorators
-# ---------------------------------------------------------------------------
 
 
 def _make_call_impl(config: _FlowModelConfig) -> _AnyCallable:

--- a/ccflow/utils/tokenize.py
+++ b/ccflow/utils/tokenize.py
@@ -441,9 +441,7 @@ _SKIPPED_METHODS = frozenset(
 )
 
 
-# ---------------------------------------------------------------------------
 # Behavior hashing — bytecode-based fingerprinting of class methods
-# ---------------------------------------------------------------------------
 
 
 def _unwrap_function(func: object) -> Callable | None:


### PR DESCRIPTION
Removes decorative comment separators — the rules of dashes above and below a heading comment:

```python
# ---------------------------------------------------------------------------
# Internal data structures
# ---------------------------------------------------------------------------
```

becomes

```python
# Internal data structures
```

They carry no information the heading does not already carry, they go stale as sections move, and they are noise in a diff whenever a line near them changes.

## Scope

Deletion only — 32 lines, zero additions:

| File | Lines removed |
| --- | --- |
| `ccflow/flow_model.py` | 22 |
| `ccflow/examples/tpch/config/conf.yaml` | 8 |
| `ccflow/utils/tokenize.py` | 2 |

Every heading comment the separators wrapped is left in place, so no documentation is lost. No code, configuration or behaviour changes.

## Verification

- `git diff --numstat` confirms `0` additions on every file.
- `ruff check` and `ruff format --check` clean.
- Test results are identical to a pristine `main` checkout run in a separate worktree: 38 failed, 1268 passed, 2 skipped, 52 errors. Those failures are an environment issue with `csp` (`AttributeError: module 'csp' has no attribute 'impl'`) and are unrelated to this change — the baseline comparison is included because a comment-only diff should be provably inert.
